### PR TITLE
Add type annotations coverage for processed projects and their source code

### DIFF
--- a/JSONOutput.md
+++ b/JSONOutput.md
@@ -14,9 +14,11 @@ After processing each project, a JSON-formatted file is produced, which is descr
           "variables": {"var_name": "type"},
           "classes": [],
           "funcs": [],
-          "set": null
+          "set": null,
+          "type_annot_cove": 0.0
         }
-    }
+    },
+    "type_annot_cove": 0.0
   }
 }
 ```
@@ -32,6 +34,7 @@ Description of the fields:
 - `classes`: Contains the JSON object of processed classes which are described below.
 - `funcs`: Contains the JSON object of processed functions in a module, which are described below.
 - `set`: Determines to which sets the file belongs to, if `--s` option is provided when running the pipeline. It contains one of the values in `['train', 'valid', 'test']`. The default value is `null`.
+- `type_annot_cove`: Type annotations coverage for source code files and the whole project.
 
 ## Classes
 The following JSON object represents a processed class:

--- a/libsa4py/cst_pipeline.py
+++ b/libsa4py/cst_pipeline.py
@@ -123,7 +123,7 @@ class Pipeline:
     def process_project(self, i, project):
 
         project_id = f'{project["author"]}/{project["repo"]}'
-        project_analyzed_files: dict = {project_id: {"src_files": {}}}
+        project_analyzed_files: dict = {project_id: {"src_files": {}, "type_annot_cove": 0.0}}
         try:
             print(f'Running pipeline for project {i} {project_id}')
             project['files'] = []
@@ -165,7 +165,6 @@ class Pipeline:
                     #logging.error("project: %s |file: %s |Exception: %s" % (project_id, filename, err))
 
             print(f'Saving available type hints for {project_id}...')
-
             if self.avl_types_dir is not None:
                 if extracted_avl_types:
                     with open(join(self.avl_types_dir, f'{project["author"]}_{project["repo"]}_avltypes.txt'),
@@ -181,6 +180,10 @@ class Pipeline:
         finally:
             try:
                 if len(project_analyzed_files[project_id]["src_files"].keys()) != 0:
+                    project_analyzed_files[project_id]["type_annot_cove"] = \
+                        round(sum([project_analyzed_files[project_id]["src_files"][s]["type_annot_cove"] for s in
+                             project_analyzed_files[project_id]["src_files"].keys()]) / len(
+                            project_analyzed_files[project_id]["src_files"].keys()), 2)
                     with open(self.get_project_filename(project), 'w') as p_json_f:
                         json.dump(project_analyzed_files, p_json_f, indent=4)
                 else:


### PR DESCRIPTION
This PR Implements #1.

- Adds the `type_annot_voce` field to the JSON file for both modules and projects
- Adds type annotation coverage for the whole processed project
- Adds type annotation coverage for each source code file of a processed project
- Updates the docs in `JSONOutput.md`