### PR TITLE
Adding qualified names for type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the [LibSA4Py](https://github.com/saltudelft/libsa4py) to
 - Minor improvement to the `SpaceAdder` code transformer for handling some rare edge cases.
 - The `--l` CLI arg for `merge` option to process a specified number of projects.
 - Adding a CST transformer to reduce the depth of parametric types.
+- Extracting type annotations with a qualified name from source code files.
 
 ### Fixed
 - Malformed output sequences containing string literal type, i.e., `Literal['Blah \n blah']`.

--- a/libsa4py/cst_lenient_parser.py
+++ b/libsa4py/cst_lenient_parser.py
@@ -33,7 +33,7 @@ class LenientPythonParser(PythonCSTParser):
                     expected_str = get_expected_str(
                         token, stack[-1].dfa.transitions.keys()
                     )
-                    raise ParseTokenError(expected_str, token.start_pos[1])
+                    raise ParseTokenError(expected_str, token, token.start_pos[1])
 
         stack[-1].dfa = plan.next_dfa
 

--- a/libsa4py/cst_lenient_parser.py
+++ b/libsa4py/cst_lenient_parser.py
@@ -1,0 +1,114 @@
+"""
+This module contains a naive lenient parser which ignores parse errors by removing problematic tokens
+NOTE: USE THIS PARSER IF YOU KNOW WHAT YOU'RE DOING!
+"""
+
+from libsa4py.exceptions import ParseTokenError
+from typing import Union
+from libcst import PartialParserConfig, CSTNode, Module
+from libcst._exceptions import get_expected_str, EOFSentinel, ParserSyntaxError
+from libcst._parser.base_parser import _token_to_transition, _TokenT, StackNode
+from libcst._parser.detect_config import detect_config
+from libcst._parser.grammar import validate_grammar, get_grammar
+from libcst._parser.python_parser import PythonCSTParser
+
+
+class LenientPythonParser(PythonCSTParser):
+    def __init__(self, *args, **kwargs):
+        super(LenientPythonParser, self).__init__(*args, **kwargs)
+
+    def _add_token(self, token: _TokenT) -> None:
+        grammar = self._pgen_grammar
+        stack = self.stack
+        transition = _token_to_transition(grammar, token.type, token.string)
+
+        while True:
+            try:
+                plan = stack[-1].dfa.transitions[transition]
+                break
+            except KeyError:
+                if stack[-1].dfa.is_final:
+                    self._pop()
+                else:
+                    expected_str = get_expected_str(
+                        token, stack[-1].dfa.transitions.keys()
+                    )
+                    raise ParseTokenError(expected_str, token.start_pos[1])
+
+        stack[-1].dfa = plan.next_dfa
+
+        for push in plan.dfa_pushes:
+            stack.append(StackNode(push))
+
+        leaf = self.convert_terminal(token)
+        stack[-1].nodes.append(leaf)
+
+    def parse(self):
+        for token in self.tokens:
+            self._add_token(token)
+
+        while True:
+            tos = self.stack[-1]
+            if not tos.dfa.is_final:
+                expected_str = get_expected_str(
+                    EOFSentinel.EOF, tos.dfa.transitions.keys()
+                )
+                raise ParserSyntaxError(
+                    f"{expected_str}",
+                    lines=self.lines,
+                    raw_line=len(self.lines),
+                    raw_column=len(self.lines[-1]),
+                )
+
+            if len(self.stack) > 1:
+                self._pop()
+            else:
+                return self.convert_nonterminal(tos.nonterminal, tos.nodes)
+
+
+def _lenient_parse(
+    entrypoint: str,
+    source: Union[str, bytes],
+    config: PartialParserConfig,
+    *,
+    detect_trailing_newline: bool,
+    detect_default_newline: bool,
+) -> CSTNode:
+    detection_result = detect_config(
+        source,
+        partial=config,
+        detect_trailing_newline=detect_trailing_newline,
+        detect_default_newline=detect_default_newline,
+    )
+    validate_grammar()
+    grammar = get_grammar(config.parsed_python_version, config.future_imports)
+    parser = LenientPythonParser(
+        tokens=detection_result.tokens,
+        config=detection_result.config,
+        pgen_grammar=grammar,
+        start_nonterminal=entrypoint,
+    )
+
+    result = parser.parse()
+    assert isinstance(result, CSTNode)
+    return result
+
+
+def lenient_parse_module(
+    source: Union[str, bytes],
+    config: PartialParserConfig = PartialParserConfig(),
+) -> Module:
+
+    try:
+        result = _lenient_parse(
+            "file_input",
+            source,
+            config,
+            detect_trailing_newline=True,
+            detect_default_newline=True,
+        )
+        assert isinstance(result, Module)
+        return result
+    except ParseTokenError as pse:
+        token, idx = pse.get_erroneous_token()
+        return lenient_parse_module(source[:idx] + '' + source[idx+1:], config)

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -813,8 +813,13 @@ class TypeQualifierResolver(cst.CSTTransformer):
                                          annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
         except cst._exceptions.ParserSyntaxError:
             # To handle a bug in LibCST's scope provider where a local name shadows a type annotation with the same name
-            return match.extract(cst.parse_module("x: %s=None" % self.q_names_cache[(self.last_visited_name.value,
-                                                                                     cst.metadata.QualifiedNameSource.IMPORT)]).body[0].body[0],
+            if (self.last_visited_name.value, cst.metadata.QualifiedNameSource.IMPORT) in self.q_names_cache:
+                return match.extract(cst.parse_module("x: %s=None" % self.q_names_cache[(self.last_visited_name.value,
+                                cst.metadata.QualifiedNameSource.IMPORT)]).body[0].body[0],
+                                 match.AnnAssign(target=match.Name(value=match.DoNotCare()),
+                                             annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
+            else:
+                return match.extract(cst.parse_module("x: %s=None" % self.last_visited_name.value).body[0].body[0],
                                  match.AnnAssign(target=match.Name(value=match.DoNotCare()),
                                                  annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
 

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -727,29 +727,29 @@ class TypeQualifierResolver(cst.CSTTransformer):
     def __init__(self):
         self.type_annot_visited: bool = False
         self.parametric_type_annot_visited: bool = False
+        self.last_visited_name: cst.Name = None
+        self.q_names_cache: Dict[Tuple[str, cst.metadata.QualifiedNameSource]] = {}
 
     def visit_Annotation(self, node: cst.Annotation):
-        if not match.matches(node, match.Annotation(annotation=match.Name(value='None'))):
+        if not match.matches(node, match.Annotation(annotation=match.OneOf(
+                match.Name(value='None'), match.List(elements=[])))):
             self.type_annot_visited = True
 
     def leave_Annotation(self, original_node: cst.Annotation, updated_node: cst.Annotation):
         if self.type_annot_visited:
             self.type_annot_visited = False
-            q_name = self.__get_qualified_name(original_node.annotation)
-            if q_name is not None:
-                if self.parametric_type_annot_visited:
-                    self.parametric_type_annot_visited = False
-                    # print("LA:", updated_node.with_changes(annotation=cst.Subscript(value=self.__name2annotation(q_name).annotation,
-                    #                              slice=updated_node.annotation.slice)))
+            if self.parametric_type_annot_visited:
+                self.parametric_type_annot_visited = False
+                q_name, _ = self.__get_qualified_name(original_node.annotation.value)
+                if q_name is not None:
                     return updated_node.with_changes(annotation=cst.Subscript(value=self.__name2annotation(q_name).annotation,
-                                                 slice=updated_node.annotation.slice))
-                else:
+                                             slice=updated_node.annotation.slice))
+            else:
+                q_name, _ = self.__get_qualified_name(original_node.annotation)
+                if q_name is not None:
                     return updated_node.with_changes(annotation=self.__name2annotation(q_name).annotation)
 
-            else:
-                return original_node
-        else:
-            return original_node
+        return original_node
 
     def visit_Subscript(self, node: cst.Subscript):
         if self.type_annot_visited:
@@ -758,9 +758,10 @@ class TypeQualifierResolver(cst.CSTTransformer):
     def leave_SubscriptElement(self, original_node: cst.SubscriptElement,
                                updated_node: cst.SubscriptElement):
         if self.type_annot_visited and self.parametric_type_annot_visited:
-            q_name = self.__get_qualified_name(original_node.slice.value)
             if match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.Subscript()))):
-                return updated_node.with_changes(slice=cst.Index(value=cst.Subscript(value=self.__name2annotation(q_name).annotation,
+                q_name, _ = self.__get_qualified_name(original_node.slice.value.value)
+                if q_name is not None:
+                    return updated_node.with_changes(slice=cst.Index(value=cst.Subscript(value=self.__name2annotation(q_name).annotation,
                                                                  slice=updated_node.slice.value.slice)))
             elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.Ellipsis()))):
                 # TODO: Should the original node be returned?!
@@ -772,40 +773,48 @@ class TypeQualifierResolver(cst.CSTTransformer):
             elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.List()))):
                 return updated_node.with_changes(slice=cst.Index(value=updated_node.slice.value))
             else:
-                return updated_node.with_changes(slice=cst.Index(value=self.__name2annotation(q_name).annotation))
-        else:
-            return original_node
+                q_name, _ = self.__get_qualified_name(original_node.slice.value)
+                if q_name is not None:
+                    return updated_node.with_changes(slice=cst.Index(value=self.__name2annotation(q_name).annotation))
+
+        return original_node
 
     def leave_Element(self, original_node: cst.Element, updated_node: cst.Element):
         if self.type_annot_visited:
-            q_name = self.__get_qualified_name(original_node.value)
+            q_name, _ = self.__get_qualified_name(original_node.value)
             return updated_node.with_changes(value=self.__name2annotation(q_name).annotation)
         else:
             return original_node
 
-    # def leave_Name(self, original_node: cst.Name, updated_node: cst.Name):
-    #     if self.type_annot_visited:
-    #         #print("Org:", original_node, "q:", self.__get_qualified_name(original_node))
-    #         #return updated_node.with_changes(value=self.__get_qualified_name(original_node))
-    #         q_name = self.__get_qualified_name(original_node)
-    #         if q_name is not None:
-    #             return updated_node.with_changes(value=self.__get_qualified_name(original_node))
-    #         else:
-    #             return original_node
-    #     else:
-    #         return original_node
+    def visit_Name(self, node: cst.Name):
+        if self.type_annot_visited:
+            self.last_visited_name = node
 
-    def __get_qualified_name(self, node) -> Optional[str]:
-        q_name = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
-        if len(q_name) != 0:
-            return list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))[0].name
+    def __get_qualified_name(self, node):
+        q = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
+        if len(q) != 0:
+            q_name, q_src = q[0].name, q[0].source
+            if q_name[0] == '.':
+                q_name = q_name[1:]
+            if (self.last_visited_name.value, q_src) not in self.q_names_cache:
+                self.q_names_cache[(self.last_visited_name.value, q_src)] = q_name
+
+            return q_name, q_src
         else:
-            return None
+            return None, None
 
     def __name2annotation(self, type_name: str):
         """
         Converts Name nodes to valid annotation nodes
         """
-        return match.extract(cst.parse_module("x: %s=None" % type_name).body[0].body[0],
-                             match.AnnAssign(target=match.Name(value=match.DoNotCare()),
-                                             annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
+        try:
+            return match.extract(cst.parse_module("x: %s=None" % type_name).body[0].body[0],
+                         match.AnnAssign(target=match.Name(value=match.DoNotCare()),
+                                         annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
+        except cst._exceptions.ParserSyntaxError:
+            # To handle a bug in LibCST's scope provider where a local name shadows a type annotation with the same name
+            return match.extract(cst.parse_module("x: %s=None" % self.q_names_cache[(self.last_visited_name.value,
+                                                                                     cst.metadata.QualifiedNameSource.IMPORT)]).body[0].body[0],
+                                 match.AnnAssign(target=match.Name(value=match.DoNotCare()),
+                                                 annotation=match.SaveMatchedNode(match.DoNotCare(), "type")))['type']
+

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -729,7 +729,6 @@ class TypeQualifierResolver(cst.CSTTransformer):
         self.parametric_type_annot_visited: bool = False
 
     def visit_Annotation(self, node: cst.Annotation):
-        #print("A", node)
         if not match.matches(node, match.Annotation(annotation=match.Name(value='None'))):
             self.type_annot_visited = True
 
@@ -764,9 +763,12 @@ class TypeQualifierResolver(cst.CSTTransformer):
                 return updated_node.with_changes(slice=cst.Index(value=cst.Subscript(value=self.__name2annotation(q_name).annotation,
                                                                  slice=updated_node.slice.value.slice)))
             elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.Ellipsis()))):
+                # TODO: Should the original node be returned?!
                 return updated_node.with_changes(slice=cst.Index(value=cst.Ellipsis()))
             elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.SimpleString(value=match.DoNotCare())))):
                 return updated_node.with_changes(slice=cst.Index(value=updated_node.slice.value))
+            elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.Name(value='None')))):
+                return original_node
             elif match.matches(original_node, match.SubscriptElement(slice=match.Index(value=match.List()))):
                 return updated_node.with_changes(slice=cst.Index(value=updated_node.slice.value))
             else:

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -794,10 +794,9 @@ class TypeQualifierResolver(cst.CSTTransformer):
         q = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
         if len(q) != 0:
             q_name, q_src = q[0].name, q[0].source
-            if re.match(r'^\.{1}[^.].+', q_name):
-                q_name = q_name[1:]
-            elif re.match(r'^\.{2}.+', q_name):
-                q_name = q_name[2:]
+            if re.match(r'^\.+.+', q_name):
+                q_name = re.sub(re.compile(r'^\.+(.+)'), r'\1', q_name)
+
             if (self.last_visited_name.value, q_src) not in self.q_names_cache:
                 self.q_names_cache[(self.last_visited_name.value, q_src)] = q_name
 

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -794,8 +794,10 @@ class TypeQualifierResolver(cst.CSTTransformer):
         q = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
         if len(q) != 0:
             q_name, q_src = q[0].name, q[0].source
-            if q_name[0] == '.':
+            if re.match(r'^\.{1}[a-zA-Z]{1}.+', q_name):
                 q_name = q_name[1:]
+            elif re.match(r'^\.{2}.+', q_name):
+                q_name = q_name[2:]
             if (self.last_visited_name.value, q_src) not in self.q_names_cache:
                 self.q_names_cache[(self.last_visited_name.value, q_src)] = q_name
 

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -794,7 +794,7 @@ class TypeQualifierResolver(cst.CSTTransformer):
         q = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
         if len(q) != 0:
             q_name, q_src = q[0].name, q[0].source
-            if re.match(r'^\.{1}[a-zA-Z]{1}.+', q_name):
+            if re.match(r'^\.{1}[^.].+', q_name):
                 q_name = q_name[1:]
             elif re.match(r'^\.{2}.+', q_name):
                 q_name = q_name[2:]

--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -401,6 +401,7 @@ class Visitor(cst.CSTVisitor):
             # Convert annotation directly to code representation
             # TODO: Adapt this to support subtokens/subtypes for generics
             converted = self.__convert_node_to_code(node.annotation)
+            #converted = self.__get_qualified_name(node.annotation)
 
             # Strip away newlines, spaces and tabs from the type
             converted = self.__clean_string_whitespace(converted)
@@ -669,6 +670,9 @@ class Visitor(cst.CSTVisitor):
         # Return empty string if docstring undefined
         return docstring if docstring is not None else ""
 
+    def __get_qualified_name(self, node):
+        return list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))[0].name
+
     def __get_type_for_names(self, names: List[cst.Name]):
         n_types: List[Tuple[cst.Name, str, Union[UNK_TYPE_ANNOT, INF_TYPE_ANNOT]]] = []
         for n in names:
@@ -681,7 +685,7 @@ class Visitor(cst.CSTVisitor):
         Extracts type of a `Name` node if `TypeInferenceProvider` given.
         """
         try:
-            q_name = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))[0].name
+            q_name = self.__get_qualified_name(node)
             ext_type = self.__clean_string_whitespace(self.get_metadata(cst.metadata.TypeInferenceProvider, node))
             # A workaround for pyre's weird inferred integers
             if bool(re.match("^typing_extensions.Literal\[[0-9]+\]$", ext_type)):

--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Union
+from typing import List, Dict, Tuple, Union, Optional
 from libsa4py.representations import FunctionInfo, ClassInfo
 from libsa4py.nl_preprocessing import extract_docstring_descriptions
 from libsa4py import DEV_TYPE_ANNOT, INF_TYPE_ANNOT, UNK_TYPE_ANNOT
@@ -34,7 +34,7 @@ class Visitor(cst.CSTVisitor):
         self.module_variables: Dict[str, str] = {}
         self.module_variables_use: Dict[str, List[list]] = {}
         self.module_all_annotations: Dict[Tuple, Tuple[str, str]] = {}
-        self.module_pyre_inferred_types: List[str] = []
+        #self.module_pyre_inferred_types: List[str] = []
         self.module_type_annot_cove: float = 0.0
         self.module_no_types: Dict[str, int] = {'U': 0, 'D': 0, 'I': 0}
 
@@ -385,7 +385,8 @@ class Visitor(cst.CSTVisitor):
             # Calculating the type annotation coverage of the module.
             all_annot_filtered = {k: v for k, v in self.module_all_annotations.items() if k[2] != 'self'}
             no_dev_type_annot = sum([1 for k, v in all_annot_filtered.items() if v[0] and v[1] == DEV_TYPE_ANNOT])
-            self.module_no_types['D'], self.module_no_types['I'] = no_dev_type_annot, len(self.module_pyre_inferred_types)
+            no_pyre_inf_annot = sum([1 for k, v in all_annot_filtered.items() if v[0] and v[1] == INF_TYPE_ANNOT])
+            self.module_no_types['D'], self.module_no_types['I'] = no_dev_type_annot, no_pyre_inf_annot
             self.module_no_types['U'] = len(all_annot_filtered.keys()) - (self.module_no_types['D'] + \
                                                                           self.module_no_types['I'])  # UNK_TYPE_ANNOT
             self.module_type_annot_cove = round(sum([1 for k, v in all_annot_filtered.items() if v[0]]) \
@@ -670,8 +671,9 @@ class Visitor(cst.CSTVisitor):
         # Return empty string if docstring undefined
         return docstring if docstring is not None else ""
 
-    def __get_qualified_name(self, node):
-        return list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))[0].name
+    def __get_qualified_name(self, node) -> Optional[str]:
+        q_name = list(self.get_metadata(cst.metadata.QualifiedNameProvider, node))
+        return q_name[0].name if len(q_name) != 0 else None
 
     def __get_type_for_names(self, names: List[cst.Name]):
         n_types: List[Tuple[cst.Name, str, Union[UNK_TYPE_ANNOT, INF_TYPE_ANNOT]]] = []
@@ -685,7 +687,6 @@ class Visitor(cst.CSTVisitor):
         Extracts type of a `Name` node if `TypeInferenceProvider` given.
         """
         try:
-            q_name = self.__get_qualified_name(node)
             ext_type = self.__clean_string_whitespace(self.get_metadata(cst.metadata.TypeInferenceProvider, node))
             # A workaround for pyre's weird inferred integers
             if bool(re.match("^typing_extensions.Literal\[[0-9]+\]$", ext_type)):
@@ -693,8 +694,9 @@ class Visitor(cst.CSTVisitor):
             elif bool(re.match("^typing_extensions.Literal\[.+\]$", ext_type)):
                 ext_type = "str"
 
-            if q_name not in self.module_pyre_inferred_types:
-                self.module_pyre_inferred_types.append(q_name)
+            # q_name = self.__get_qualified_name(node)
+            # if q_name is not None and q_name not in self.module_pyre_inferred_types:
+            #     self.module_pyre_inferred_types.append(q_name)
 
             return ext_type
 

--- a/libsa4py/exceptions.py
+++ b/libsa4py/exceptions.py
@@ -1,6 +1,19 @@
+from typing import Tuple
+
+
 class ParseError(Exception):
     def __init__(self, msg: str):
         super().__init__("ParseError: " + msg)
+
+
+class ParseTokenError(Exception):
+    def __init__(self, token: str, token_idx: int):
+        super().__init__("Failed parsing token: " + token)
+        self.token = token
+        self.token_idx = token_idx
+
+    def get_erroneous_token(self) -> Tuple[str, int]:
+        return self.token, self.token_idx
 
 
 class OutputSequenceException(Exception):
@@ -10,6 +23,7 @@ class OutputSequenceException(Exception):
 
     def __init__(self, in_seq: str, out_seq: str):
         super().__init__("Malformed output sequence: " + in_seq + " -> " + out_seq)
+
 
 class NullProjectException(Exception):
     """

--- a/libsa4py/exceptions.py
+++ b/libsa4py/exceptions.py
@@ -7,8 +7,8 @@ class ParseError(Exception):
 
 
 class ParseTokenError(Exception):
-    def __init__(self, token: str, token_idx: int):
-        super().__init__("Failed parsing token: " + token)
+    def __init__(self, msg: str, token: str, token_idx: int):
+        super().__init__("Failed parsing token: " + msg)
         self.token = token
         self.token_idx = token_idx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-libcst
+libcst>=0.3.18
 numpy
 pandas
 nltk

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -1,9 +1,11 @@
 from typing import Dict as _Dict
 from typing import Tuple, Union
 from libsa4py.cst_transformers import TypeQualifierResolver
+from .representations import Bar
 import typing as t
 import typing
 from collections.abc import Sequence
+from builtins import str
 import numpy as np
 import builtins
 
@@ -20,6 +22,7 @@ tqr: TypeQualifierResolver = TypeQualifierResolver()
 lt: t.Literal["123"] = "123"
 s: [] = [1, 2]
 N: Union[t.List, None] = []
+rl: Bar = Bar()
 
 class Foo:
     foo_seq: Sequence = []
@@ -29,6 +32,12 @@ class Foo:
 
     def bar(self) -> np.array:
         return np.array([1, 2, 3])
+
+    def shadow_qn(self):
+        sq: str = 'Shadow qualified name'
+
+        for str in sq:
+            print(str)
 
 u: "Foo" = Foo(t_e)
 foo: Foo = Foo(t_e)

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -23,6 +23,7 @@ lt: t.Literal["123"] = "123"
 s: [] = [1, 2]
 N: Union[t.List, None] = []
 rl: Bar = Bar()
+b: True = True
 
 class Foo:
     foo_seq: Sequence = []

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -27,8 +27,11 @@ rl: Bar = Bar()
 class Foo:
     foo_seq: Sequence = []
     def __init__(self, x: t.Tuple, y: t.Pattern=None):
+        class Delta:
+            pass
         self.x: Tuple = x
         n: np.int = np.int(12)
+        d: Delta = Delta()
 
     def bar(self) -> np.array:
         return np.array([1, 2, 3])

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -1,18 +1,34 @@
 from typing import Dict as _Dict
-from typing import Tuple
+from typing import Tuple, Union
+from libsa4py.cst_transformers import TypeQualifierResolver
 import typing as t
+import typing
 from collections.abc import Sequence
 import numpy as np
 import builtins
 
 d: _Dict = {}
 l: t.List[str] = []
+q_v: typing.List[builtins.int] = [10]
+l_n: t.List[Tuple[int, int]]
+t_e: t.Tuple[typing.Any, ...] = ()
+u_d: Union[t.List[Tuple[str, int]], t.Tuple[t.Any], t.Tuple[t.List[t.Tuple[t.Set[int]]]]] = None
+c: t.Callable[..., t.List] = None
+c_h: t.Callable[[t.List, t.Dict], int] = None
+t_a: t.Type[t.List] = t.List
+tqr: TypeQualifierResolver = TypeQualifierResolver()
+lt: t.Literal["123"] = "123"
+s: [] = [1, 2]
 
 class Foo:
     foo_seq: Sequence = []
-    def __init__(self, x: t.Tuple, y: t.Pattern):
+    def __init__(self, x: t.Tuple, y: t.Pattern=None):
         self.x: Tuple = x
         n: np.int = np.int(12)
 
     def bar(self) -> np.array:
         return np.array([1, 2, 3])
+
+u: "Foo" = Foo(t_e)
+foo: Foo = Foo(t_e)
+foo_t: Tuple[Foo, TypeQualifierResolver] = (Foo(t_e), TypeQualifierResolver())

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -2,6 +2,7 @@ from typing import Dict as _Dict
 from typing import Tuple, Union
 from libsa4py.cst_transformers import TypeQualifierResolver
 from .representations import Bar
+from ..test_imports import TestImports
 import typing as t
 import typing
 from collections.abc import Sequence
@@ -24,6 +25,7 @@ s: [] = [1, 2]
 N: Union[t.List, None] = []
 rl: Bar = Bar()
 b: True = True
+relative_i: TestImports = TestImports()
 
 class Foo:
     foo_seq: Sequence = []

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -19,6 +19,7 @@ t_a: t.Type[t.List] = t.List
 tqr: TypeQualifierResolver = TypeQualifierResolver()
 lt: t.Literal["123"] = "123"
 s: [] = [1, 2]
+N: Union[t.List, None] = []
 
 class Foo:
     foo_seq: Sequence = []

--- a/tests/examples/qualified_types.py
+++ b/tests/examples/qualified_types.py
@@ -1,0 +1,18 @@
+from typing import Dict as _Dict
+from typing import Tuple
+import typing as t
+from collections.abc import Sequence
+import numpy as np
+import builtins
+
+d: _Dict = {}
+l: t.List[str] = []
+
+class Foo:
+    foo_seq: Sequence = []
+    def __init__(self, x: t.Tuple, y: t.Pattern):
+        self.x: Tuple = x
+        n: np.int = np.int(12)
+
+    def bar(self) -> np.array:
+        return np.array([1, 2, 3])

--- a/tests/exp_outputs/extractor_out.json
+++ b/tests/exp_outputs/extractor_out.json
@@ -1,6 +1,6 @@
 {
     "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
-    "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
+    "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
     "imports": [
         "path",
         "math"
@@ -15,7 +15,7 @@
         {
             "name": "MyClass",
             "variables": {
-                "cls_var": "int"
+                "cls_var": "builtins.int"
             },
             "cls_var_occur": {
                 "cls_var": [
@@ -32,7 +32,7 @@
                     "name": "__init__",
                     "params": {
                         "self": "",
-                        "y": "float"
+                        "y": "builtins.float"
                     },
                     "ret_exprs": [],
                     "params_occur": {
@@ -78,7 +78,7 @@
                     "name": "cls_fn",
                     "params": {
                         "self": "",
-                        "c": "int"
+                        "c": "builtins.int"
                     },
                     "ret_exprs": [
                         "return MyClass.cls_var + c / (2 + n)"
@@ -98,7 +98,7 @@
                             ]
                         ]
                     },
-                    "ret_type": "float",
+                    "ret_type": "builtins.float",
                     "variables": {
                         "n": ""
                     },
@@ -161,7 +161,7 @@
         {
             "name": "my_fn",
             "params": {
-                "x": "int"
+                "x": "builtins.int"
             },
             "ret_exprs": [
                 "return x + 10"
@@ -169,7 +169,7 @@
             "params_occur": {
                 "x": []
             },
-            "ret_type": "int",
+            "ret_type": "builtins.int",
             "variables": {},
             "fn_var_occur": {},
             "params_descr": {

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -33,6 +33,71 @@
                 },
                 "type_annot_cove": 0.0
             },
+            "libsa4py/tests/examples/shadow_qn.py": {
+                "untyped_seq": "from builtins import str [EOL] [EOL] def bar ( ) : [EOL] x = [string] [EOL] [EOL] def foo ( ) : [EOL] p = [string] [EOL] [EOL] for str in [ [string] , [string] ] : [EOL] print ( str ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [
+                    "str"
+                ],
+                "variables": {},
+                "mod_var_occur": {},
+                "classes": [],
+                "funcs": [
+                    {
+                        "name": "bar",
+                        "params": {},
+                        "ret_exprs": [],
+                        "params_occur": {},
+                        "ret_type": "",
+                        "variables": {
+                            "x": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "x": [
+                                "x",
+                                "builtins",
+                                "str"
+                            ]
+                        },
+                        "params_descr": {},
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    },
+                    {
+                        "name": "foo",
+                        "params": {},
+                        "ret_exprs": [],
+                        "params_occur": {},
+                        "ret_type": "",
+                        "variables": {
+                            "p": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "p": [
+                                "p",
+                                "builtins",
+                                "str"
+                            ]
+                        },
+                        "params_descr": {},
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    }
+                ],
+                "set": null,
+                "no_types_annot": {
+                    "U": 2,
+                    "D": 2,
+                    "I": 0
+                },
+                "type_annot_cove": 0.5
+            },
             "libsa4py/tests/examples/comment_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] [comment] [EOL] x = [number] [comment] [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [EOL] def delta ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] class Foo : [EOL] [docstring] [EOL] [EOL] def bar ( self ) : [EOL] [docstring] [EOL] [comment] [EOL] pass [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -99,16 +164,18 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
                     "Union",
                     "TypeQualifierResolver",
+                    "Bar",
                     "typing",
                     "typing",
                     "Sequence",
+                    "str",
                     "numpy",
                     "builtins"
                 ],
@@ -126,6 +193,7 @@
                     "lt": "typing.Literal[\"123\"]",
                     "s": "[]",
                     "n": "typing.Union[typing.List, None]",
+                    "rl": "representations.Bar",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -162,6 +230,7 @@
                     "lt": [],
                     "s": [],
                     "N": [],
+                    "rl": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -255,6 +324,35 @@
                                     "ret": null,
                                     "long_descr": null
                                 }
+                            },
+                            {
+                                "name": "shadow qn",
+                                "params": {
+                                    "self": ""
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": []
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "sq": "builtins.str"
+                                },
+                                "fn_var_occur": {
+                                    "sq": [
+                                        "sq",
+                                        "builtins",
+                                        "str"
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
                             }
                         ]
                     }
@@ -262,11 +360,11 @@
                 "funcs": [],
                 "set": null,
                 "no_types_annot": {
-                    "U": 1,
-                    "D": 21,
+                    "U": 2,
+                    "D": 23,
                     "I": 0
                 },
-                "type_annot_cove": 0.95
+                "type_annot_cove": 0.92
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",
@@ -2574,6 +2672,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.37
+        "type_annot_cove": 0.38
     }
 }

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -164,8 +164,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -199,7 +199,11 @@
                     "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
                 },
                 "mod_var_occur": {
-                    "d": [],
+                    "d": [
+                        "",
+                        "delta",
+                        "delta"
+                    ],
                     "l": [],
                     "q_v": [],
                     "l_n": [],
@@ -237,6 +241,12 @@
                 },
                 "classes": [
                     {
+                        "name": "Delta",
+                        "variables": {},
+                        "cls_var_occur": {},
+                        "funcs": []
+                    },
+                    {
                         "name": "Foo",
                         "variables": {
                             "foo seq": "collections.abc.Sequence"
@@ -273,7 +283,8 @@
                                 "ret_type": "",
                                 "variables": {
                                     "x": "typing.Tuple",
-                                    "n": "numpy.int"
+                                    "n": "numpy.int",
+                                    "d": "Delta"
                                 },
                                 "fn_var_occur": {
                                     "x": [
@@ -289,6 +300,11 @@
                                         "int",
                                         "np",
                                         "int"
+                                    ],
+                                    "d": [
+                                        "",
+                                        "delta",
+                                        "delta"
                                     ]
                                 },
                                 "params_descr": {
@@ -361,7 +377,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 23,
+                    "D": 24,
                     "I": 0
                 },
                 "type_annot_cove": 0.92

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -99,14 +99,15 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] from . . test_imports import TestImports [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] relative_i = TestImports ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 $test_imports.TestImports$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
                     "Union",
                     "TypeQualifierResolver",
                     "Bar",
+                    "TestImports",
                     "typing",
                     "typing",
                     "Sequence",
@@ -130,6 +131,7 @@
                     "n": "typing.Union[typing.List, None]",
                     "rl": "representations.Bar",
                     "b": "True",
+                    "relative i": "test_imports.TestImports",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -172,6 +174,7 @@
                     "N": [],
                     "rl": [],
                     "b": [],
+                    "relative_i": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -314,7 +317,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 25,
+                    "D": 26,
                     "I": 0
                 },
                 "type_annot_cove": 0.93

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -164,8 +164,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -194,6 +194,7 @@
                     "s": "[]",
                     "n": "typing.Union[typing.List, None]",
                     "rl": "representations.Bar",
+                    "b": "True",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -235,6 +236,7 @@
                     "s": [],
                     "N": [],
                     "rl": [],
+                    "b": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -377,10 +379,10 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 24,
+                    "D": 25,
                     "I": 0
                 },
-                "type_annot_cove": 0.92
+                "type_annot_cove": 0.93
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -99,8 +99,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -125,6 +125,7 @@
                     "tqr": "libsa4py.cst_transformers.TypeQualifierResolver",
                     "lt": "typing.Literal[\"123\"]",
                     "s": "[]",
+                    "n": "typing.Union[typing.List, None]",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -160,6 +161,7 @@
                     "tqr": [],
                     "lt": [],
                     "s": [],
+                    "N": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -261,7 +263,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 1,
-                    "D": 20,
+                    "D": 21,
                     "I": 0
                 },
                 "type_annot_cove": 0.95

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -98,12 +98,133 @@
                 },
                 "type_annot_cove": 0.0
             },
+            "libsa4py/tests/examples/qualified_types.py": {
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple [EOL] import typing as t [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [
+                    "Dict",
+                    "Tuple",
+                    "typing",
+                    "Sequence",
+                    "numpy",
+                    "builtins"
+                ],
+                "variables": {
+                    "d": "typing.Dict",
+                    "l": "typing.List[builtins.str]"
+                },
+                "mod_var_occur": {
+                    "d": [],
+                    "l": []
+                },
+                "classes": [
+                    {
+                        "name": "Foo",
+                        "variables": {
+                            "foo seq": "collections.abc.Sequence"
+                        },
+                        "cls_var_occur": {
+                            "foo_seq": []
+                        },
+                        "funcs": [
+                            {
+                                "name": "init",
+                                "params": {
+                                    "self": "",
+                                    "x": "typing.Tuple",
+                                    "y": "typing.Pattern"
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": [
+                                        "self",
+                                        "x",
+                                        "type",
+                                        "tuple",
+                                        "x"
+                                    ],
+                                    "x": [
+                                        "self",
+                                        "x",
+                                        "type",
+                                        "tuple",
+                                        "x"
+                                    ],
+                                    "y": []
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "x": "typing.Tuple",
+                                    "n": "numpy.int"
+                                },
+                                "fn_var_occur": {
+                                    "x": [
+                                        "self",
+                                        "x",
+                                        "type",
+                                        "tuple",
+                                        "x"
+                                    ],
+                                    "n": [
+                                        "n",
+                                        "numpy",
+                                        "int",
+                                        "np",
+                                        "int"
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": "",
+                                    "x": "",
+                                    "y": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            },
+                            {
+                                "name": "bar",
+                                "params": {
+                                    "self": ""
+                                },
+                                "ret_exprs": [
+                                    "np array"
+                                ],
+                                "params_occur": {
+                                    "self": []
+                                },
+                                "ret_type": "numpy.array",
+                                "variables": {},
+                                "fn_var_occur": {},
+                                "params_descr": {
+                                    "self": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "funcs": [],
+                "set": null,
+                "no_types_annot": {
+                    "U": 1,
+                    "D": 7,
+                    "I": 0
+                },
+                "type_annot_cove": 0.88
+            },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",
-                "typed_seq": "0 0 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $float$ 0 0 0 0 0 0 0 0 $float$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 $int$ 0",
+                "typed_seq": "0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 $builtins.int$ 0",
                 "imports": [],
                 "variables": {
-                    "constant": "int",
+                    "constant": "builtins.int",
                     "constant use": ""
                 },
                 "mod_var_occur": {
@@ -128,13 +249,14 @@
                     {
                         "name": "Bar",
                         "variables": {
-                            "me": "float",
+                            "me": "builtins.float",
                             "fox": ""
                         },
                         "cls_var_occur": {
                             "me": [
                                 "self",
                                 "c",
+                                "builtins",
                                 "float",
                                 "bar",
                                 ""
@@ -152,6 +274,7 @@
                                     "self": [
                                         "self",
                                         "c",
+                                        "builtins",
                                         "float",
                                         "bar",
                                         "",
@@ -164,13 +287,14 @@
                                 },
                                 "ret_type": "",
                                 "variables": {
-                                    "c": "float",
+                                    "c": "builtins.float",
                                     "b": ""
                                 },
                                 "fn_var_occur": {
                                     "c": [
                                         "self",
                                         "c",
+                                        "builtins",
                                         "float",
                                         "bar",
                                         "",
@@ -204,23 +328,25 @@
                     {
                         "name": "foo",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
                             "x": [
                                 "",
+                                "builtins",
                                 "int",
                                 "x"
                             ]
                         },
                         "ret_type": "",
                         "variables": {
-                            "y": "int"
+                            "y": "builtins.int"
                         },
                         "fn_var_occur": {
                             "y": [
                                 "",
+                                "builtins",
                                 "int",
                                 "x",
                                 "print",
@@ -248,13 +374,13 @@
             },
             "libsa4py/tests/examples/vars_args_occur.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from . different_fns import add [EOL] [EOL] [EOL] PI = [number] [EOL] MOD_CONSTANT = [number] [EOL] [EOL] [EOL] class TestVarArgOccur : [EOL] [EOL] greeting = [string] [EOL] num = [number] [EOL] cls_constant = MOD_CONSTANT + [number] [EOL] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] self . y = y [EOL] [EOL] def fn_params_occur ( self , param1 , param2 ) : [EOL] z = param1 + param2 [EOL] [EOL] add_x_y = add ( param1 , param2 ) [EOL] [EOL] list_comp = [ i for i in range ( param1 ** param2 * z ) ] [EOL] [EOL] if param1 * add_x_y == [number] : [EOL] pass [EOL] elif param1 % param2 < [number] : [EOL] pass [EOL] [EOL] while param2 * param1 * z // [number] : [EOL] pass [EOL] [EOL] for i in range ( param1 + z * [number] ) : [EOL] pass [EOL] [EOL] with z * param2 as f : [EOL] print ( z ** param2 / f ) [EOL] [EOL] assert param1 == add_x_y * z [EOL] yield z + param2 [EOL] return param1 + [number] + param2 / [number] [EOL] [EOL] def local_vars_usage ( self , p ) : [EOL] v = sum ( [ [number] , [number] , [number] , [number] ] ) [EOL] v_1 = v + p + [number] [EOL] [EOL] for i in range ( [number] , v + v_1 ) : [EOL] i += v + [number] [EOL] yield i + v_1 [EOL] [EOL] if v < [number] and v_1 + v > [number] : [EOL] print ( v ) [EOL] [EOL] elif v * v_1 != [number] : [EOL] print ( v * v_1 ) [EOL] else : [EOL] print ( v_1 ) [EOL] [EOL] while v + v_1 < p : [EOL] v *= [number] + v_1 [EOL] [EOL] with ( v_1 + p // [number] ) as n : [EOL] assert v != n [EOL] [EOL] return v + p + p + [number] [EOL] [EOL] [comment] [EOL] def class_vars_usage ( self ) : [EOL] c = self . x + TestVarArgOccur . num [EOL] [EOL] if TestVarArgOccur . num + c < [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , TestVarArgOccur . num ) : [EOL] yield TestVarArgOccur . num + i [EOL] [EOL] while TestVarArgOccur . num < [number] : [EOL] TestVarArgOccur . num -= [number] [EOL] [EOL] with ( TestVarArgOccur . greeting + [string] ) as f : [EOL] pass [EOL] [EOL] assert c != TestVarArgOccur . cls_constant [EOL] [EOL] return TestVarArgOccur . cls_constant + c [EOL] [EOL] [comment] [EOL] def module_vars_usage ( self , add_something ) : [EOL] if PI + add_something > [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , int ( PI ) ) : [EOL] pass [EOL] [EOL] while PI + MOD_CONSTANT > [number] : [EOL] PI = - [number] + add_something [EOL] [EOL] with ( MOD_CONSTANT + PI + add_something ) as n : [EOL] print ( n ) [EOL] [EOL] def formatted_str ( self , p ) : [EOL] x = [number] [EOL] y = [number] [EOL] print ( f\" [string] { x * y // p } [string] \" ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 $int$ 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 $builtins.int$ 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "add"
                 ],
                 "variables": {
                     "pi": "",
-                    "mod constant": "int"
+                    "mod constant": "builtins.int"
                 },
                 "mod_var_occur": {
                     "PI": [
@@ -287,7 +413,7 @@
                     {
                         "name": "TestVarArgOccur",
                         "variables": {
-                            "greet": "str",
+                            "greet": "builtins.str",
                             "num": "",
                             "cl constant": ""
                         },
@@ -331,7 +457,7 @@
                                 "name": "init",
                                 "params": {
                                     "self": "",
-                                    "x": "int",
+                                    "x": "builtins.int",
                                     "y": ""
                                 },
                                 "ret_exprs": [],
@@ -387,7 +513,7 @@
                                 "name": "fn params occur",
                                 "params": {
                                     "self": "",
-                                    "param": "int"
+                                    "param": "builtins.int"
                                 },
                                 "ret_exprs": [
                                     "param param"
@@ -559,6 +685,7 @@
                                 "fn_var_occur": {
                                     "v": [
                                         "v",
+                                        "builtins",
                                         "int",
                                         "sum",
                                         "v",
@@ -989,11 +1116,11 @@
             },
             "libsa4py/tests/examples/type_annot_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] MOD = ... [EOL] [EOL] def foo ( x , l ) : [EOL] return l [ x ] [EOL] [EOL] class Bar : [EOL] class_var = [string] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . n = ... [EOL]",
-                "typed_seq": "0 0 0 $int$ 0 0 0 $dict$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 $None$ 0 0 0 $float$ 0 0 0 0 0 $float$ 0 $float$ 0 0 0 $set$ 0 0 0",
+                "typed_seq": "0 0 0 $builtins.int$ 0 0 0 $builtins.dict$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 $None$ 0 0 0 $builtins.float$ 0 0 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 $builtins.set$ 0 0 0",
                 "imports": [],
                 "variables": {
-                    "constant": "int",
-                    "mod": "dict"
+                    "constant": "builtins.int",
+                    "mod": "builtins.dict"
                 },
                 "mod_var_occur": {
                     "CONSTANT": [],
@@ -1003,7 +1130,7 @@
                     {
                         "name": "Bar",
                         "variables": {
-                            "class var": "str"
+                            "class var": "builtins.str"
                         },
                         "cls_var_occur": {
                             "class_var": []
@@ -1013,41 +1140,46 @@
                                 "name": "init",
                                 "params": {
                                     "self": "",
-                                    "x": "float"
+                                    "x": "builtins.float"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
                                     "self": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "float",
                                         "x",
                                         "self",
                                         "n",
+                                        "builtins",
                                         "set"
                                     ],
                                     "x": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "float",
                                         "x"
                                     ]
                                 },
                                 "ret_type": "None",
                                 "variables": {
-                                    "x": "float",
-                                    "n": "set"
+                                    "x": "builtins.float",
+                                    "n": "builtins.set"
                                 },
                                 "fn_var_occur": {
                                     "x": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "float",
                                         "x"
                                     ],
                                     "n": [
                                         "self",
                                         "n",
+                                        "builtins",
                                         "set"
                                     ]
                                 },
@@ -1068,8 +1200,8 @@
                     {
                         "name": "foo",
                         "params": {
-                            "x": "int",
-                            "l": "list"
+                            "x": "builtins.int",
+                            "l": "builtins.list"
                         },
                         "ret_exprs": [
                             "l x"
@@ -1084,7 +1216,7 @@
                                 "x"
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -1108,13 +1240,13 @@
             },
             "libsa4py/tests/examples/assignments.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import List [EOL] [EOL] [comment] [EOL] PI = [number] [EOL] CONSTANT = [number] [EOL] M_FOO , M_BAR = [number] , [number] [EOL] [EOL] LONG_STRING = [string] [EOL] [EOL] [EOL] class Test : [EOL] [comment] [EOL] x = [number] [EOL] u , f = [number] , [string] [EOL] out_y = [string] [EOL] scientific_num = [number] [EOL] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . y = [string] [EOL] self . b , self . c = [number] , [string] [EOL] self . error = ... [EOL] [EOL] def local_var_assings ( self ) : [EOL] f_no = [number] [EOL] l = [ [string] , [string] ] [EOL] foo = ... [EOL] [EOL] def tuple_assigns ( self ) : [EOL] x , y , z = [number] , [number] , [number] [EOL] a , ( b , c ) = [number] , ( [number] , [number] ) [EOL] d , ( ( e , f ) , ( g , h ) ) = [number] , ( ( [number] , [number] ) , ( [number] , [number] ) ) [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [comment]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List$ 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 $List[str]$ 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "List"
                 ],
                 "variables": {
                     "pi": "",
-                    "constant": "int",
+                    "constant": "builtins.int",
                     "m foo": "",
                     "m bar": "",
                     "long string": ""
@@ -1133,7 +1265,7 @@
                             "x": "",
                             "u": "",
                             "f": "",
-                            "out y": "str",
+                            "out y": "builtins.str",
                             "scientific num": ""
                         },
                         "cls_var_occur": {
@@ -1148,13 +1280,14 @@
                                 "name": "init",
                                 "params": {
                                     "self": "",
-                                    "x": "int"
+                                    "x": "builtins.int"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
                                     "self": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "int",
                                         "x",
                                         "self",
@@ -1165,27 +1298,30 @@
                                         "c",
                                         "self",
                                         "error",
+                                        "type",
                                         "list"
                                     ],
                                     "x": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "int",
                                         "x"
                                     ]
                                 },
                                 "ret_type": "None",
                                 "variables": {
-                                    "x": "int",
+                                    "x": "builtins.int",
                                     "y": "",
                                     "b": "",
                                     "c": "",
-                                    "error": "List"
+                                    "error": "typing.List"
                                 },
                                 "fn_var_occur": {
                                     "x": [
                                         "self",
                                         "x",
+                                        "builtins",
                                         "int",
                                         "x"
                                     ],
@@ -1208,6 +1344,7 @@
                                     "error": [
                                         "self",
                                         "error",
+                                        "type",
                                         "list"
                                     ]
                                 },
@@ -1232,22 +1369,26 @@
                                 },
                                 "ret_type": "",
                                 "variables": {
-                                    "f no": "float",
-                                    "l": "List[str]",
-                                    "foo": "str"
+                                    "f no": "builtins.float",
+                                    "l": "typing.List[builtins.str]",
+                                    "foo": "builtins.str"
                                 },
                                 "fn_var_occur": {
                                     "f_no": [
                                         "f",
+                                        "builtins",
                                         "float"
                                     ],
                                     "l": [
                                         "l",
+                                        "type",
                                         "list",
+                                        "builtins",
                                         "str"
                                     ],
                                     "foo": [
                                         "foo",
+                                        "builtins",
                                         "str"
                                     ]
                                 },
@@ -1373,11 +1514,11 @@
             },
             "libsa4py/tests/examples/vars_types_pyre.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] PI = [number] [EOL] no = [number] [EOL] CONSTANT = [string] [EOL] X , Y = [number] , [number] [EOL] [EOL] class Foo : [EOL] foo_num = [number] [EOL] foo_name = [string] [EOL] foo_x , foo_y = [number] , [ [number] , [number] , [number] ] [EOL] [EOL] def __init__ ( self , t = [string] ) : [EOL] self . x = [ [number] , [number] , [number] ] [EOL] self . y = t [EOL] self . l , self . k = ( [number] , [number] ) , [string] [EOL] [EOL] def local_vars ( self ) : [EOL] x = ( [string] , [string] ) [EOL] f , g = [number] , [number] [EOL] res = PI + f [EOL] [EOL] [EOL] [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [],
                 "variables": {
                     "pi": "",
-                    "no": "int",
+                    "no": "builtins.int",
                     "constant": "",
                     "x": "",
                     "y": ""
@@ -1532,18 +1673,18 @@
             },
             "libsa4py/tests/examples/space_tokens.py": {
                 "untyped_seq": "[docstring] [EOL] from typing import List [EOL] import math as m [EOL] [EOL] CONSTANT = [number] [EOL] STRING = [string] [EOL] [EOL] [string] [string] == STRING [EOL] [EOL] d = { k : v for k , v in [ ( [number] , [number] ) , ( [number] , [number] ) ] } [EOL] d_e = { ** d , ** d } [EOL] [EOL] f_str = f\" [string] { STRING + STRING }\" [EOL] [EOL] l = [ [number] , [number] , [number] , [number] ] [EOL] [EOL] print ( l [ [number] ] ) [EOL] [EOL] class Delta : [EOL] def __init__ ( self ) : [EOL] self . x = [string] [EOL] [EOL] def foo ( x , y , * s ) : [EOL] global CONSTANT [EOL] n = [number] [EOL] n //= n % x [EOL] y %= x ; x **= n [EOL] if x | x & y | ~ y | x ^ y : [EOL] x << y [EOL] y >> x [EOL] s <<= x [EOL] x >>= y [EOL] y &= x [EOL] x |= y [EOL] x ^= y [EOL] if x <= y or y >= x and ~ x : [EOL] pass [EOL] [EOL] assert x != y [EOL] [EOL] return n + x // y [EOL] [EOL] @ set def bar ( x ) : [EOL] v = foo ( x , [number] ) [EOL] try : [EOL] v /= x [EOL] except ZeroDivisionError : [EOL] raise RuntimeError [EOL] finally : [EOL] pass [EOL] if x < v and v > x : [EOL] x *= x [EOL] else : [EOL] pass [EOL] del x [EOL] return v [EOL] [EOL] for i in range ( CONSTANT + [number] + bar ( [number] ) ) : [EOL] if i + foo ( i , [number] ) + [number] : [EOL] print ( i / i ) [EOL] i += [number] - [number] ** [number] [EOL] i -= [number] [EOL] while i < [number] : [EOL] i = i + [number] [EOL] [EOL] with ( i + [number] ) as w : [EOL] pass [EOL] [EOL] foo ( [number] , [number] , * l )",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0",
                 "imports": [
                     "List",
                     "math"
                 ],
                 "variables": {
-                    "constant": "int",
+                    "constant": "builtins.int",
                     "string": "",
                     "d": "",
                     "d e": "",
                     "f str": "",
-                    "l": "List[ int ]",
+                    "l": "typing.List[builtins.int]",
                     "i": ""
                 },
                 "mod_var_occur": {
@@ -1739,7 +1880,7 @@
                     {
                         "name": "bar",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "v"
@@ -1759,7 +1900,7 @@
                                 "x"
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
                             "v": ""
                         },
@@ -1796,7 +1937,7 @@
             },
             "libsa4py/tests/examples/different_fns.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $Optional[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0",
                 "imports": [
                     "Optional"
                 ],
@@ -1807,8 +1948,8 @@
                     {
                         "name": "add",
                         "params": {
-                            "x": "int",
-                            "y": "int"
+                            "x": "builtins.int",
+                            "y": "builtins.int"
                         },
                         "ret_exprs": [
                             "x y"
@@ -1823,7 +1964,7 @@
                                 ""
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -1843,7 +1984,7 @@
                             ""
                         ],
                         "params_occur": {},
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {},
@@ -1873,7 +2014,7 @@
                     {
                         "name": "noreturn",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
@@ -1897,7 +2038,7 @@
                     {
                         "name": "return none",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
@@ -1921,7 +2062,7 @@
                     {
                         "name": "return optional",
                         "params": {
-                            "y": "list"
+                            "y": "builtins.list"
                         },
                         "ret_exprs": [
                             "none",
@@ -1933,7 +2074,7 @@
                                 ""
                             ]
                         },
-                        "ret_type": "Optional[int]",
+                        "ret_type": "typing.Optional[builtins.int]",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -1964,7 +2105,7 @@
                                 ""
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -1980,7 +2121,7 @@
                     {
                         "name": "inner",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "x"
@@ -1988,7 +2129,7 @@
                         "params_occur": {
                             "x": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2020,7 +2161,7 @@
                     {
                         "name": "varargs",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "sum"
@@ -2028,13 +2169,14 @@
                         "params_occur": {
                             "xs": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
-                            "sum": "int"
+                            "sum": "builtins.int"
                         },
                         "fn_var_occur": {
                             "sum": [
                                 "sum",
+                                "builtins",
                                 "int",
                                 "sum",
                                 "x"
@@ -2060,13 +2202,14 @@
                         "params_occur": {
                             "xs": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
-                            "sum": "int"
+                            "sum": "builtins.int"
                         },
                         "fn_var_occur": {
                             "sum": [
                                 "sum",
+                                "builtins",
                                 "int",
                                 "sum",
                                 "x"
@@ -2084,9 +2227,9 @@
                     {
                         "name": "kwarg method",
                         "params": {
-                            "a": "int",
-                            "b": "int",
-                            "c": "float"
+                            "a": "builtins.int",
+                            "b": "builtins.int",
+                            "c": "builtins.float"
                         },
                         "ret_exprs": [
                             "c"
@@ -2113,7 +2256,7 @@
                     {
                         "name": "async fn",
                         "params": {
-                            "y": "int"
+                            "y": "builtins.int"
                         },
                         "ret_exprs": [
                             "await y"
@@ -2121,7 +2264,7 @@
                         "params_occur": {
                             "y": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2136,13 +2279,13 @@
                     {
                         "name": "abstract fn",
                         "params": {
-                            "name": "str"
+                            "name": "builtins.str"
                         },
                         "ret_exprs": [],
                         "params_occur": {
                             "name": []
                         },
-                        "ret_type": "str",
+                        "ret_type": "builtins.str",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2165,7 +2308,7 @@
             },
             "libsa4py/tests/examples/representations.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "path",
                     "math"
@@ -2180,7 +2323,7 @@
                     {
                         "name": "MyClass",
                         "variables": {
-                            "cl var": "int"
+                            "cl var": "builtins.int"
                         },
                         "cls_var_occur": {
                             "cls_var": [
@@ -2195,7 +2338,7 @@
                                 "name": "init",
                                 "params": {
                                     "self": "",
-                                    "y": "float"
+                                    "y": "builtins.float"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
@@ -2235,7 +2378,7 @@
                                 "name": "cl fn",
                                 "params": {
                                     "self": "",
-                                    "c": "int"
+                                    "c": "builtins.int"
                                 },
                                 "ret_exprs": [
                                     "my class cl var c n"
@@ -2251,7 +2394,7 @@
                                         "n"
                                     ]
                                 },
-                                "ret_type": "float",
+                                "ret_type": "builtins.float",
                                 "variables": {
                                     "n": ""
                                 },
@@ -2310,7 +2453,7 @@
                     {
                         "name": "my fn",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "x"
@@ -2318,7 +2461,7 @@
                         "params_occur": {
                             "x": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2382,6 +2525,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.33
+        "type_annot_cove": 0.37
     }
 }

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -33,71 +33,6 @@
                 },
                 "type_annot_cove": 0.0
             },
-            "libsa4py/tests/examples/shadow_qn.py": {
-                "untyped_seq": "from builtins import str [EOL] [EOL] def bar ( ) : [EOL] x = [string] [EOL] [EOL] def foo ( ) : [EOL] p = [string] [EOL] [EOL] for str in [ [string] , [string] ] : [EOL] print ( str ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
-                "imports": [
-                    "str"
-                ],
-                "variables": {},
-                "mod_var_occur": {},
-                "classes": [],
-                "funcs": [
-                    {
-                        "name": "bar",
-                        "params": {},
-                        "ret_exprs": [],
-                        "params_occur": {},
-                        "ret_type": "",
-                        "variables": {
-                            "x": "builtins.str"
-                        },
-                        "fn_var_occur": {
-                            "x": [
-                                "x",
-                                "builtins",
-                                "str"
-                            ]
-                        },
-                        "params_descr": {},
-                        "docstring": {
-                            "func": null,
-                            "ret": null,
-                            "long_descr": null
-                        }
-                    },
-                    {
-                        "name": "foo",
-                        "params": {},
-                        "ret_exprs": [],
-                        "params_occur": {},
-                        "ret_type": "",
-                        "variables": {
-                            "p": "builtins.str"
-                        },
-                        "fn_var_occur": {
-                            "p": [
-                                "p",
-                                "builtins",
-                                "str"
-                            ]
-                        },
-                        "params_descr": {},
-                        "docstring": {
-                            "func": null,
-                            "ret": null,
-                            "long_descr": null
-                        }
-                    }
-                ],
-                "set": null,
-                "no_types_annot": {
-                    "U": 2,
-                    "D": 2,
-                    "I": 0
-                },
-                "type_annot_cove": 0.5
-            },
             "libsa4py/tests/examples/comment_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] [comment] [EOL] x = [number] [comment] [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [EOL] def delta ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] class Foo : [EOL] [docstring] [EOL] [EOL] def bar ( self ) : [EOL] [docstring] [EOL] [comment] [EOL] pass [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -2690,6 +2625,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.38
+        "type_annot_cove": 0.37
     }
 }

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -99,11 +99,14 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple [EOL] import typing as t [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
+                    "Union",
+                    "TypeQualifierResolver",
+                    "typing",
                     "typing",
                     "Sequence",
                     "numpy",
@@ -111,11 +114,55 @@
                 ],
                 "variables": {
                     "d": "typing.Dict",
-                    "l": "typing.List[builtins.str]"
+                    "l": "typing.List[builtins.str]",
+                    "q v": "typing.List[builtins.int]",
+                    "l n": "typing.List[typing.Tuple[builtins.int, builtins.int]]",
+                    "t e": "typing.Tuple[typing.Any, ...]",
+                    "u d": "typing.Union[typing.List[typing.Tuple[builtins.str, builtins.int]], typing.Tuple[typing.Any], typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]",
+                    "c": "typing.Callable[..., typing.List]",
+                    "c h": "typing.Callable[[typing.List, typing.Dict], builtins.int]",
+                    "t a": "typing.Type[typing.List]",
+                    "tqr": "libsa4py.cst_transformers.TypeQualifierResolver",
+                    "lt": "typing.Literal[\"123\"]",
+                    "s": "[]",
+                    "u": "\"Foo\"",
+                    "foo": "Foo",
+                    "foo t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
                 },
                 "mod_var_occur": {
                     "d": [],
-                    "l": []
+                    "l": [],
+                    "q_v": [],
+                    "l_n": [],
+                    "t_e": [
+                        "u",
+                        "foo",
+                        "e",
+                        "foo",
+                        "foo",
+                        "foo",
+                        "e",
+                        "foo",
+                        "type",
+                        "tuple",
+                        "foo",
+                        "libsa py",
+                        "cst transformer",
+                        "type qualifier resolver",
+                        "foo",
+                        "e",
+                        "type qualifier resolver"
+                    ],
+                    "u_d": [],
+                    "c": [],
+                    "c_h": [],
+                    "t_a": [],
+                    "tqr": [],
+                    "lt": [],
+                    "s": [],
+                    "u": [],
+                    "foo": [],
+                    "foo_t": []
                 },
                 "classes": [
                     {
@@ -214,10 +261,10 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 1,
-                    "D": 7,
+                    "D": 20,
                     "I": 0
                 },
-                "type_annot_cove": 0.88
+                "type_annot_cove": 0.95
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -99,8 +99,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -125,6 +125,7 @@
                     "tqr": "libsa4py.cst_transformers.TypeQualifierResolver",
                     "lt": "typing.Literal[\"123\"]",
                     "s": "[]",
+                    "N": "typing.Union[typing.List, None]",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -166,6 +167,7 @@
                     "tqr": [],
                     "lt": [],
                     "s": [],
+                    "N": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -275,7 +277,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 1,
-                    "D": 20,
+                    "D": 21,
                     "I": 0
                 },
                 "type_annot_cove": 0.95

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -99,11 +99,14 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple [EOL] import typing as t [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
+                    "Union",
+                    "TypeQualifierResolver",
+                    "typing",
                     "typing",
                     "Sequence",
                     "numpy",
@@ -111,11 +114,61 @@
                 ],
                 "variables": {
                     "d": "typing.Dict",
-                    "l": "typing.List[builtins.str]"
+                    "l": "typing.List[builtins.str]",
+                    "q_v": "typing.List[builtins.int]",
+                    "l_n": "typing.List[typing.Tuple[builtins.int, builtins.int]]",
+                    "t_e": "typing.Tuple[typing.Any, ...]",
+                    "u_d": "typing.Union[typing.List[typing.Tuple[builtins.str, builtins.int]], typing.Tuple[typing.Any], typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]",
+                    "c": "typing.Callable[..., typing.List]",
+                    "c_h": "typing.Callable[[typing.List, typing.Dict], builtins.int]",
+                    "t_a": "typing.Type[typing.List]",
+                    "tqr": "libsa4py.cst_transformers.TypeQualifierResolver",
+                    "lt": "typing.Literal[\"123\"]",
+                    "s": "[]",
+                    "u": "\"Foo\"",
+                    "foo": "Foo",
+                    "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
                 },
                 "mod_var_occur": {
                     "d": [],
-                    "l": []
+                    "l": [],
+                    "q_v": [],
+                    "l_n": [],
+                    "t_e": [
+                        [
+                            "u",
+                            "Foo",
+                            "t_e"
+                        ],
+                        [
+                            "foo",
+                            "Foo",
+                            "Foo",
+                            "t_e"
+                        ],
+                        [
+                            "foo_t",
+                            "typing",
+                            "Tuple",
+                            "Foo",
+                            "libsa4py",
+                            "cst_transformers",
+                            "TypeQualifierResolver",
+                            "Foo",
+                            "t_e",
+                            "TypeQualifierResolver"
+                        ]
+                    ],
+                    "u_d": [],
+                    "c": [],
+                    "c_h": [],
+                    "t_a": [],
+                    "tqr": [],
+                    "lt": [],
+                    "s": [],
+                    "u": [],
+                    "foo": [],
+                    "foo_t": []
                 },
                 "classes": [
                     {
@@ -222,10 +275,10 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 1,
-                    "D": 7,
+                    "D": 20,
                     "I": 0
                 },
-                "type_annot_cove": 0.88
+                "type_annot_cove": 0.95
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -168,8 +168,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -198,6 +198,7 @@
                     "s": "[]",
                     "N": "typing.Union[typing.List, None]",
                     "rl": "representations.Bar",
+                    "b": "True",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -247,6 +248,7 @@
                     "s": [],
                     "N": [],
                     "rl": [],
+                    "b": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -401,10 +403,10 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 24,
+                    "D": 25,
                     "I": 0
                 },
-                "type_annot_cove": 0.92
+                "type_annot_cove": 0.93
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -98,12 +98,141 @@
                 },
                 "type_annot_cove": 0.0
             },
+            "libsa4py/tests/examples/qualified_types.py": {
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple [EOL] import typing as t [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [
+                    "Dict",
+                    "Tuple",
+                    "typing",
+                    "Sequence",
+                    "numpy",
+                    "builtins"
+                ],
+                "variables": {
+                    "d": "typing.Dict",
+                    "l": "typing.List[builtins.str]"
+                },
+                "mod_var_occur": {
+                    "d": [],
+                    "l": []
+                },
+                "classes": [
+                    {
+                        "name": "Foo",
+                        "variables": {
+                            "foo_seq": "collections.abc.Sequence"
+                        },
+                        "cls_var_occur": {
+                            "foo_seq": []
+                        },
+                        "funcs": [
+                            {
+                                "name": "__init__",
+                                "params": {
+                                    "self": "",
+                                    "x": "typing.Tuple",
+                                    "y": "typing.Pattern"
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": [
+                                        [
+                                            "self",
+                                            "x",
+                                            "typing",
+                                            "Tuple",
+                                            "x"
+                                        ]
+                                    ],
+                                    "x": [
+                                        [
+                                            "self",
+                                            "x",
+                                            "typing",
+                                            "Tuple",
+                                            "x"
+                                        ]
+                                    ],
+                                    "y": []
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "x": "typing.Tuple",
+                                    "n": "numpy.int"
+                                },
+                                "fn_var_occur": {
+                                    "x": [
+                                        [
+                                            "self",
+                                            "x",
+                                            "typing",
+                                            "Tuple",
+                                            "x"
+                                        ]
+                                    ],
+                                    "n": [
+                                        [
+                                            "n",
+                                            "numpy",
+                                            "int",
+                                            "np",
+                                            "int"
+                                        ]
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": "",
+                                    "x": "",
+                                    "y": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            },
+                            {
+                                "name": "bar",
+                                "params": {
+                                    "self": ""
+                                },
+                                "ret_exprs": [
+                                    "return np.array([1, 2, 3])"
+                                ],
+                                "params_occur": {
+                                    "self": []
+                                },
+                                "ret_type": "numpy.array",
+                                "variables": {},
+                                "fn_var_occur": {},
+                                "params_descr": {
+                                    "self": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "funcs": [],
+                "set": null,
+                "no_types_annot": {
+                    "U": 1,
+                    "D": 7,
+                    "I": 0
+                },
+                "type_annot_cove": 0.88
+            },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",
-                "typed_seq": "0 0 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $float$ 0 0 0 0 0 0 0 0 $float$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 $int$ 0",
+                "typed_seq": "0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 $builtins.int$ 0",
                 "imports": [],
                 "variables": {
-                    "CONSTANT": "int",
+                    "CONSTANT": "builtins.int",
                     "CONSTANT_USED": ""
                 },
                 "mod_var_occur": {
@@ -136,7 +265,7 @@
                     {
                         "name": "Bar",
                         "variables": {
-                            "me": "float",
+                            "me": "builtins.float",
                             "fox": ""
                         },
                         "cls_var_occur": {
@@ -144,6 +273,7 @@
                                 [
                                     "self",
                                     "c",
+                                    "builtins",
                                     "float",
                                     "Bar",
                                     "me"
@@ -163,6 +293,7 @@
                                         [
                                             "self",
                                             "c",
+                                            "builtins",
                                             "float",
                                             "Bar",
                                             "me"
@@ -178,7 +309,7 @@
                                 },
                                 "ret_type": "",
                                 "variables": {
-                                    "c": "float",
+                                    "c": "builtins.float",
                                     "b": ""
                                 },
                                 "fn_var_occur": {
@@ -186,6 +317,7 @@
                                         [
                                             "self",
                                             "c",
+                                            "builtins",
                                             "float",
                                             "Bar",
                                             "me"
@@ -224,13 +356,14 @@
                     {
                         "name": "foo",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
                             "x": [
                                 [
                                     "y",
+                                    "builtins",
                                     "int",
                                     "x"
                                 ]
@@ -238,12 +371,13 @@
                         },
                         "ret_type": "",
                         "variables": {
-                            "y": "int"
+                            "y": "builtins.int"
                         },
                         "fn_var_occur": {
                             "y": [
                                 [
                                     "y",
+                                    "builtins",
                                     "int",
                                     "x"
                                 ],
@@ -274,13 +408,13 @@
             },
             "libsa4py/tests/examples/vars_args_occur.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from . different_fns import add [EOL] [EOL] [EOL] PI = [number] [EOL] MOD_CONSTANT = [number] [EOL] [EOL] [EOL] class TestVarArgOccur : [EOL] [EOL] greeting = [string] [EOL] num = [number] [EOL] cls_constant = MOD_CONSTANT + [number] [EOL] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] self . y = y [EOL] [EOL] def fn_params_occur ( self , param1 , param2 ) : [EOL] z = param1 + param2 [EOL] [EOL] add_x_y = add ( param1 , param2 ) [EOL] [EOL] list_comp = [ i for i in range ( param1 ** param2 * z ) ] [EOL] [EOL] if param1 * add_x_y == [number] : [EOL] pass [EOL] elif param1 % param2 < [number] : [EOL] pass [EOL] [EOL] while param2 * param1 * z // [number] : [EOL] pass [EOL] [EOL] for i in range ( param1 + z * [number] ) : [EOL] pass [EOL] [EOL] with z * param2 as f : [EOL] print ( z ** param2 / f ) [EOL] [EOL] assert param1 == add_x_y * z [EOL] yield z + param2 [EOL] return param1 + [number] + param2 / [number] [EOL] [EOL] def local_vars_usage ( self , p ) : [EOL] v = sum ( [ [number] , [number] , [number] , [number] ] ) [EOL] v_1 = v + p + [number] [EOL] [EOL] for i in range ( [number] , v + v_1 ) : [EOL] i += v + [number] [EOL] yield i + v_1 [EOL] [EOL] if v < [number] and v_1 + v > [number] : [EOL] print ( v ) [EOL] [EOL] elif v * v_1 != [number] : [EOL] print ( v * v_1 ) [EOL] else : [EOL] print ( v_1 ) [EOL] [EOL] while v + v_1 < p : [EOL] v *= [number] + v_1 [EOL] [EOL] with ( v_1 + p // [number] ) as n : [EOL] assert v != n [EOL] [EOL] return v + p + p + [number] [EOL] [EOL] [comment] [EOL] def class_vars_usage ( self ) : [EOL] c = self . x + TestVarArgOccur . num [EOL] [EOL] if TestVarArgOccur . num + c < [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , TestVarArgOccur . num ) : [EOL] yield TestVarArgOccur . num + i [EOL] [EOL] while TestVarArgOccur . num < [number] : [EOL] TestVarArgOccur . num -= [number] [EOL] [EOL] with ( TestVarArgOccur . greeting + [string] ) as f : [EOL] pass [EOL] [EOL] assert c != TestVarArgOccur . cls_constant [EOL] [EOL] return TestVarArgOccur . cls_constant + c [EOL] [EOL] [comment] [EOL] def module_vars_usage ( self , add_something ) : [EOL] if PI + add_something > [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , int ( PI ) ) : [EOL] pass [EOL] [EOL] while PI + MOD_CONSTANT > [number] : [EOL] PI = - [number] + add_something [EOL] [EOL] with ( MOD_CONSTANT + PI + add_something ) as n : [EOL] print ( n ) [EOL] [EOL] def formatted_str ( self , p ) : [EOL] x = [number] [EOL] y = [number] [EOL] print ( f\" [string] { x * y // p } [string] \" ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 $int$ 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 $builtins.int$ 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "add"
                 ],
                 "variables": {
                     "PI": "",
-                    "MOD_CONSTANT": "int"
+                    "MOD_CONSTANT": "builtins.int"
                 },
                 "mod_var_occur": {
                     "PI": [
@@ -329,7 +463,7 @@
                     {
                         "name": "TestVarArgOccur",
                         "variables": {
-                            "greeting": "str",
+                            "greeting": "builtins.str",
                             "num": "",
                             "cls_constant": ""
                         },
@@ -391,7 +525,7 @@
                                 "name": "__init__",
                                 "params": {
                                     "self": "",
-                                    "x": "int",
+                                    "x": "builtins.int",
                                     "y": ""
                                 },
                                 "ret_exprs": [],
@@ -459,8 +593,8 @@
                                 "name": "fn_params_occur",
                                 "params": {
                                     "self": "",
-                                    "param1": "int",
-                                    "param2": "int"
+                                    "param1": "builtins.int",
+                                    "param2": "builtins.int"
                                 },
                                 "ret_exprs": [
                                     "return param1 + 2 + param2 / 5"
@@ -696,13 +830,14 @@
                                 },
                                 "ret_type": "",
                                 "variables": {
-                                    "v": "int",
+                                    "v": "builtins.int",
                                     "v_1": ""
                                 },
                                 "fn_var_occur": {
                                     "v": [
                                         [
                                             "v",
+                                            "builtins",
                                             "int",
                                             "sum"
                                         ],
@@ -1226,11 +1361,11 @@
             },
             "libsa4py/tests/examples/type_annot_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] MOD = ... [EOL] [EOL] def foo ( x , l ) : [EOL] return l [ x ] [EOL] [EOL] class Bar : [EOL] class_var = [string] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . n = ... [EOL]",
-                "typed_seq": "0 0 0 $int$ 0 0 0 $dict$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 $None$ 0 0 0 $float$ 0 0 0 0 0 $float$ 0 $float$ 0 0 0 $set$ 0 0 0",
+                "typed_seq": "0 0 0 $builtins.int$ 0 0 0 $builtins.dict$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 $None$ 0 0 0 $builtins.float$ 0 0 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 $builtins.set$ 0 0 0",
                 "imports": [],
                 "variables": {
-                    "CONSTANT": "int",
-                    "MOD": "dict"
+                    "CONSTANT": "builtins.int",
+                    "MOD": "builtins.dict"
                 },
                 "mod_var_occur": {
                     "CONSTANT": [],
@@ -1240,7 +1375,7 @@
                     {
                         "name": "Bar",
                         "variables": {
-                            "class_var": "str"
+                            "class_var": "builtins.str"
                         },
                         "cls_var_occur": {
                             "class_var": []
@@ -1250,7 +1385,7 @@
                                 "name": "__init__",
                                 "params": {
                                     "self": "",
-                                    "x": "float"
+                                    "x": "builtins.float"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
@@ -1258,12 +1393,14 @@
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "float",
                                             "x"
                                         ],
                                         [
                                             "self",
                                             "n",
+                                            "builtins",
                                             "set"
                                         ]
                                     ],
@@ -1271,6 +1408,7 @@
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "float",
                                             "x"
                                         ]
@@ -1278,14 +1416,15 @@
                                 },
                                 "ret_type": "None",
                                 "variables": {
-                                    "x": "float",
-                                    "n": "set"
+                                    "x": "builtins.float",
+                                    "n": "builtins.set"
                                 },
                                 "fn_var_occur": {
                                     "x": [
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "float",
                                             "x"
                                         ]
@@ -1294,6 +1433,7 @@
                                         [
                                             "self",
                                             "n",
+                                            "builtins",
                                             "set"
                                         ]
                                     ]
@@ -1315,8 +1455,8 @@
                     {
                         "name": "foo",
                         "params": {
-                            "x": "int",
-                            "l": "list"
+                            "x": "builtins.int",
+                            "l": "builtins.list"
                         },
                         "ret_exprs": [
                             "return l[x]"
@@ -1335,7 +1475,7 @@
                                 ]
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -1359,13 +1499,13 @@
             },
             "libsa4py/tests/examples/assignments.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import List [EOL] [EOL] [comment] [EOL] PI = [number] [EOL] CONSTANT = [number] [EOL] M_FOO , M_BAR = [number] , [number] [EOL] [EOL] LONG_STRING = [string] [EOL] [EOL] [EOL] class Test : [EOL] [comment] [EOL] x = [number] [EOL] u , f = [number] , [string] [EOL] out_y = [string] [EOL] scientific_num = [number] [EOL] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . y = [string] [EOL] self . b , self . c = [number] , [string] [EOL] self . error = ... [EOL] [EOL] def local_var_assings ( self ) : [EOL] f_no = [number] [EOL] l = [ [string] , [string] ] [EOL] foo = ... [EOL] [EOL] def tuple_assigns ( self ) : [EOL] x , y , z = [number] , [number] , [number] [EOL] a , ( b , c ) = [number] , ( [number] , [number] ) [EOL] d , ( ( e , f ) , ( g , h ) ) = [number] , ( ( [number] , [number] ) , ( [number] , [number] ) ) [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [comment]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List$ 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 $List[str]$ 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "List"
                 ],
                 "variables": {
                     "PI": "",
-                    "CONSTANT": "int",
+                    "CONSTANT": "builtins.int",
                     "M_FOO": "",
                     "M_BAR": "",
                     "LONG_STRING": ""
@@ -1384,7 +1524,7 @@
                             "x": "",
                             "u": "",
                             "f": "",
-                            "out_y": "str",
+                            "out_y": "builtins.str",
                             "scientific_num": ""
                         },
                         "cls_var_occur": {
@@ -1399,7 +1539,7 @@
                                 "name": "__init__",
                                 "params": {
                                     "self": "",
-                                    "x": "int"
+                                    "x": "builtins.int"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
@@ -1407,6 +1547,7 @@
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "int",
                                             "x"
                                         ],
@@ -1423,6 +1564,7 @@
                                         [
                                             "self",
                                             "error",
+                                            "typing",
                                             "List"
                                         ]
                                     ],
@@ -1430,6 +1572,7 @@
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "int",
                                             "x"
                                         ]
@@ -1437,17 +1580,18 @@
                                 },
                                 "ret_type": "None",
                                 "variables": {
-                                    "x": "int",
+                                    "x": "builtins.int",
                                     "y": "",
                                     "b": "",
                                     "c": "",
-                                    "error": "List"
+                                    "error": "typing.List"
                                 },
                                 "fn_var_occur": {
                                     "x": [
                                         [
                                             "self",
                                             "x",
+                                            "builtins",
                                             "int",
                                             "x"
                                         ]
@@ -1478,6 +1622,7 @@
                                         [
                                             "self",
                                             "error",
+                                            "typing",
                                             "List"
                                         ]
                                     ]
@@ -1503,27 +1648,31 @@
                                 },
                                 "ret_type": "",
                                 "variables": {
-                                    "f_no": "float",
-                                    "l": "List[str]",
-                                    "foo": "str"
+                                    "f_no": "builtins.float",
+                                    "l": "typing.List[builtins.str]",
+                                    "foo": "builtins.str"
                                 },
                                 "fn_var_occur": {
                                     "f_no": [
                                         [
                                             "f_no",
+                                            "builtins",
                                             "float"
                                         ]
                                     ],
                                     "l": [
                                         [
                                             "l",
+                                            "typing",
                                             "List",
+                                            "builtins",
                                             "str"
                                         ]
                                     ],
                                     "foo": [
                                         [
                                             "foo",
+                                            "builtins",
                                             "str"
                                         ]
                                     ]
@@ -1672,11 +1821,11 @@
             },
             "libsa4py/tests/examples/vars_types_pyre.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] PI = [number] [EOL] no = [number] [EOL] CONSTANT = [string] [EOL] X , Y = [number] , [number] [EOL] [EOL] class Foo : [EOL] foo_num = [number] [EOL] foo_name = [string] [EOL] foo_x , foo_y = [number] , [ [number] , [number] , [number] ] [EOL] [EOL] def __init__ ( self , t = [string] ) : [EOL] self . x = [ [number] , [number] , [number] ] [EOL] self . y = t [EOL] self . l , self . k = ( [number] , [number] ) , [string] [EOL] [EOL] def local_vars ( self ) : [EOL] x = ( [string] , [string] ) [EOL] f , g = [number] , [number] [EOL] res = PI + f [EOL] [EOL] [EOL] [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [],
                 "variables": {
                     "PI": "",
-                    "no": "int",
+                    "no": "builtins.int",
                     "CONSTANT": "",
                     "X": "",
                     "Y": ""
@@ -1857,18 +2006,18 @@
             },
             "libsa4py/tests/examples/space_tokens.py": {
                 "untyped_seq": "[docstring] [EOL] from typing import List [EOL] import math as m [EOL] [EOL] CONSTANT = [number] [EOL] STRING = [string] [EOL] [EOL] [string] [string] == STRING [EOL] [EOL] d = { k : v for k , v in [ ( [number] , [number] ) , ( [number] , [number] ) ] } [EOL] d_e = { ** d , ** d } [EOL] [EOL] f_str = f\" [string] { STRING + STRING }\" [EOL] [EOL] l = [ [number] , [number] , [number] , [number] ] [EOL] [EOL] print ( l [ [number] ] ) [EOL] [EOL] class Delta : [EOL] def __init__ ( self ) : [EOL] self . x = [string] [EOL] [EOL] def foo ( x , y , * s ) : [EOL] global CONSTANT [EOL] n = [number] [EOL] n //= n % x [EOL] y %= x ; x **= n [EOL] if x | x & y | ~ y | x ^ y : [EOL] x << y [EOL] y >> x [EOL] s <<= x [EOL] x >>= y [EOL] y &= x [EOL] x |= y [EOL] x ^= y [EOL] if x <= y or y >= x and ~ x : [EOL] pass [EOL] [EOL] assert x != y [EOL] [EOL] return n + x // y [EOL] [EOL] @ set def bar ( x ) : [EOL] v = foo ( x , [number] ) [EOL] try : [EOL] v /= x [EOL] except ZeroDivisionError : [EOL] raise RuntimeError [EOL] finally : [EOL] pass [EOL] if x < v and v > x : [EOL] x *= x [EOL] else : [EOL] pass [EOL] del x [EOL] return v [EOL] [EOL] for i in range ( CONSTANT + [number] + bar ( [number] ) ) : [EOL] if i + foo ( i , [number] ) + [number] : [EOL] print ( i / i ) [EOL] i += [number] - [number] ** [number] [EOL] i -= [number] [EOL] while i < [number] : [EOL] i = i + [number] [EOL] [EOL] with ( i + [number] ) as w : [EOL] pass [EOL] [EOL] foo ( [number] , [number] , * l )",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $List[int]$ 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0",
                 "imports": [
                     "List",
                     "math"
                 ],
                 "variables": {
-                    "CONSTANT": "int",
+                    "CONSTANT": "builtins.int",
                     "STRING": "",
                     "d": "",
                     "d_e": "",
                     "f_str": "",
-                    "l": "List[ int ]",
+                    "l": "typing.List[builtins.int]",
                     "i": ""
                 },
                 "mod_var_occur": {
@@ -2140,7 +2289,7 @@
                     {
                         "name": "bar",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "return v"
@@ -2168,7 +2317,7 @@
                                 ]
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
                             "v": ""
                         },
@@ -2211,7 +2360,7 @@
             },
             "libsa4py/tests/examples/different_fns.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $Optional[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $str$ 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0",
                 "imports": [
                     "Optional"
                 ],
@@ -2222,8 +2371,8 @@
                     {
                         "name": "add",
                         "params": {
-                            "x": "int",
-                            "y": "int"
+                            "x": "builtins.int",
+                            "y": "builtins.int"
                         },
                         "ret_exprs": [
                             "return x + y"
@@ -2242,7 +2391,7 @@
                                 ]
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2262,7 +2411,7 @@
                             "return 5"
                         ],
                         "params_occur": {},
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {},
@@ -2292,7 +2441,7 @@
                     {
                         "name": "noreturn",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
@@ -2318,7 +2467,7 @@
                     {
                         "name": "return_none",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [],
                         "params_occur": {
@@ -2344,7 +2493,7 @@
                     {
                         "name": "return_optional",
                         "params": {
-                            "y": "list"
+                            "y": "builtins.list"
                         },
                         "ret_exprs": [
                             "return None",
@@ -2358,7 +2507,7 @@
                                 ]
                             ]
                         },
-                        "ret_type": "Optional[int]",
+                        "ret_type": "typing.Optional[builtins.int]",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2393,7 +2542,7 @@
                                 ]
                             ]
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2409,7 +2558,7 @@
                     {
                         "name": "inner",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "return 12 + x"
@@ -2417,7 +2566,7 @@
                         "params_occur": {
                             "x": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2449,7 +2598,7 @@
                     {
                         "name": "varargs",
                         "params": {
-                            "xs": "int"
+                            "xs": "builtins.int"
                         },
                         "ret_exprs": [
                             "return sum"
@@ -2457,14 +2606,15 @@
                         "params_occur": {
                             "xs": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
-                            "sum": "int"
+                            "sum": "builtins.int"
                         },
                         "fn_var_occur": {
                             "sum": [
                                 [
                                     "sum",
+                                    "builtins",
                                     "int"
                                 ],
                                 [
@@ -2493,14 +2643,15 @@
                         "params_occur": {
                             "xs": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {
-                            "sum": "int"
+                            "sum": "builtins.int"
                         },
                         "fn_var_occur": {
                             "sum": [
                                 [
                                     "sum",
+                                    "builtins",
                                     "int"
                                 ],
                                 [
@@ -2521,9 +2672,9 @@
                     {
                         "name": "kwarg_method",
                         "params": {
-                            "a": "int",
-                            "b": "int",
-                            "c": "float"
+                            "a": "builtins.int",
+                            "b": "builtins.int",
+                            "c": "builtins.float"
                         },
                         "ret_exprs": [
                             "return c"
@@ -2550,7 +2701,7 @@
                     {
                         "name": "async_fn",
                         "params": {
-                            "y": "int"
+                            "y": "builtins.int"
                         },
                         "ret_exprs": [
                             "return await y"
@@ -2558,7 +2709,7 @@
                         "params_occur": {
                             "y": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2573,13 +2724,13 @@
                     {
                         "name": "abstract_fn",
                         "params": {
-                            "name": "str"
+                            "name": "builtins.str"
                         },
                         "ret_exprs": [],
                         "params_occur": {
                             "name": []
                         },
-                        "ret_type": "str",
+                        "ret_type": "builtins.str",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2602,7 +2753,7 @@
             },
             "libsa4py/tests/examples/representations.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "path",
                     "math"
@@ -2617,7 +2768,7 @@
                     {
                         "name": "MyClass",
                         "variables": {
-                            "cls_var": "int"
+                            "cls_var": "builtins.int"
                         },
                         "cls_var_occur": {
                             "cls_var": [
@@ -2634,7 +2785,7 @@
                                 "name": "__init__",
                                 "params": {
                                     "self": "",
-                                    "y": "float"
+                                    "y": "builtins.float"
                                 },
                                 "ret_exprs": [],
                                 "params_occur": {
@@ -2680,7 +2831,7 @@
                                 "name": "cls_fn",
                                 "params": {
                                     "self": "",
-                                    "c": "int"
+                                    "c": "builtins.int"
                                 },
                                 "ret_exprs": [
                                     "return MyClass.cls_var + c / (2 + n)"
@@ -2700,7 +2851,7 @@
                                         ]
                                     ]
                                 },
-                                "ret_type": "float",
+                                "ret_type": "builtins.float",
                                 "variables": {
                                     "n": ""
                                 },
@@ -2763,7 +2914,7 @@
                     {
                         "name": "my_fn",
                         "params": {
-                            "x": "int"
+                            "x": "builtins.int"
                         },
                         "ret_exprs": [
                             "return x + 10"
@@ -2771,7 +2922,7 @@
                         "params_occur": {
                             "x": []
                         },
-                        "ret_type": "int",
+                        "ret_type": "builtins.int",
                         "variables": {},
                         "fn_var_occur": {},
                         "params_descr": {
@@ -2837,6 +2988,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.33
+        "type_annot_cove": 0.37
     }
 }

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -99,14 +99,15 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] from . . test_imports import TestImports [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] relative_i = TestImports ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 $test_imports.TestImports$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
                     "Union",
                     "TypeQualifierResolver",
                     "Bar",
+                    "TestImports",
                     "typing",
                     "typing",
                     "Sequence",
@@ -130,6 +131,7 @@
                     "N": "typing.Union[typing.List, None]",
                     "rl": "representations.Bar",
                     "b": "True",
+                    "relative_i": "test_imports.TestImports",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -180,6 +182,7 @@
                     "N": [],
                     "rl": [],
                     "b": [],
+                    "relative_i": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -334,7 +337,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 25,
+                    "D": 26,
                     "I": 0
                 },
                 "type_annot_cove": 0.93

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -33,75 +33,6 @@
                 },
                 "type_annot_cove": 0.0
             },
-            "libsa4py/tests/examples/shadow_qn.py": {
-                "untyped_seq": "from builtins import str [EOL] [EOL] def bar ( ) : [EOL] x = [string] [EOL] [EOL] def foo ( ) : [EOL] p = [string] [EOL] [EOL] for str in [ [string] , [string] ] : [EOL] print ( str ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
-                "imports": [
-                    "str"
-                ],
-                "variables": {},
-                "mod_var_occur": {},
-                "classes": [],
-                "funcs": [
-                    {
-                        "name": "bar",
-                        "params": {},
-                        "ret_exprs": [],
-                        "params_occur": {},
-                        "ret_type": "",
-                        "variables": {
-                            "x": "builtins.str"
-                        },
-                        "fn_var_occur": {
-                            "x": [
-                                [
-                                    "x",
-                                    "builtins",
-                                    "str"
-                                ]
-                            ]
-                        },
-                        "params_descr": {},
-                        "docstring": {
-                            "func": null,
-                            "ret": null,
-                            "long_descr": null
-                        }
-                    },
-                    {
-                        "name": "foo",
-                        "params": {},
-                        "ret_exprs": [],
-                        "params_occur": {},
-                        "ret_type": "",
-                        "variables": {
-                            "p": "builtins.str"
-                        },
-                        "fn_var_occur": {
-                            "p": [
-                                [
-                                    "p",
-                                    "builtins",
-                                    "str"
-                                ]
-                            ]
-                        },
-                        "params_descr": {},
-                        "docstring": {
-                            "func": null,
-                            "ret": null,
-                            "long_descr": null
-                        }
-                    }
-                ],
-                "set": null,
-                "no_types_annot": {
-                    "U": 2,
-                    "D": 2,
-                    "I": 0
-                },
-                "type_annot_cove": 0.5
-            },
             "libsa4py/tests/examples/comment_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] [comment] [EOL] x = [number] [comment] [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [EOL] def delta ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] class Foo : [EOL] [docstring] [EOL] [EOL] def bar ( self ) : [EOL] [docstring] [EOL] [comment] [EOL] pass [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -3169,6 +3100,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.38
+        "type_annot_cove": 0.37
     }
 }

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -33,6 +33,75 @@
                 },
                 "type_annot_cove": 0.0
             },
+            "libsa4py/tests/examples/shadow_qn.py": {
+                "untyped_seq": "from builtins import str [EOL] [EOL] def bar ( ) : [EOL] x = [string] [EOL] [EOL] def foo ( ) : [EOL] p = [string] [EOL] [EOL] for str in [ [string] , [string] ] : [EOL] print ( str ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [
+                    "str"
+                ],
+                "variables": {},
+                "mod_var_occur": {},
+                "classes": [],
+                "funcs": [
+                    {
+                        "name": "bar",
+                        "params": {},
+                        "ret_exprs": [],
+                        "params_occur": {},
+                        "ret_type": "",
+                        "variables": {
+                            "x": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "x": [
+                                [
+                                    "x",
+                                    "builtins",
+                                    "str"
+                                ]
+                            ]
+                        },
+                        "params_descr": {},
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    },
+                    {
+                        "name": "foo",
+                        "params": {},
+                        "ret_exprs": [],
+                        "params_occur": {},
+                        "ret_type": "",
+                        "variables": {
+                            "p": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "p": [
+                                [
+                                    "p",
+                                    "builtins",
+                                    "str"
+                                ]
+                            ]
+                        },
+                        "params_descr": {},
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    }
+                ],
+                "set": null,
+                "no_types_annot": {
+                    "U": 2,
+                    "D": 2,
+                    "I": 0
+                },
+                "type_annot_cove": 0.5
+            },
             "libsa4py/tests/examples/comment_removal.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] [comment] [EOL] x = [number] [comment] [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [EOL] def delta ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] class Foo : [EOL] [docstring] [EOL] [EOL] def bar ( self ) : [EOL] [docstring] [EOL] [comment] [EOL] pass [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -99,16 +168,18 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
                     "Union",
                     "TypeQualifierResolver",
+                    "Bar",
                     "typing",
                     "typing",
                     "Sequence",
+                    "str",
                     "numpy",
                     "builtins"
                 ],
@@ -126,6 +197,7 @@
                     "lt": "typing.Literal[\"123\"]",
                     "s": "[]",
                     "N": "typing.Union[typing.List, None]",
+                    "rl": "representations.Bar",
                     "u": "\"Foo\"",
                     "foo": "Foo",
                     "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
@@ -168,6 +240,7 @@
                     "lt": [],
                     "s": [],
                     "N": [],
+                    "rl": [],
                     "u": [],
                     "foo": [],
                     "foo_t": []
@@ -269,6 +342,37 @@
                                     "ret": null,
                                     "long_descr": null
                                 }
+                            },
+                            {
+                                "name": "shadow_qn",
+                                "params": {
+                                    "self": ""
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": []
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "sq": "builtins.str"
+                                },
+                                "fn_var_occur": {
+                                    "sq": [
+                                        [
+                                            "sq",
+                                            "builtins",
+                                            "str"
+                                        ]
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
                             }
                         ]
                     }
@@ -276,11 +380,11 @@
                 "funcs": [],
                 "set": null,
                 "no_types_annot": {
-                    "U": 1,
-                    "D": 21,
+                    "U": 2,
+                    "D": 23,
                     "I": 0
                 },
-                "type_annot_cove": 0.95
+                "type_annot_cove": 0.92
             },
             "libsa4py/tests/examples/types_prop.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] CONSTANT = [number] [EOL] CONSTANT_USED = [number] + CONSTANT [EOL] [EOL] def foo ( x ) : [EOL] y = x + [number] [comment] [EOL] print ( y + CONSTANT ) [comment] [EOL] [EOL] class Bar : [EOL] me = [number] [comment] [EOL] fox = [number] + me + CONSTANT [comment] [EOL] def __init__ ( self ) : [EOL] self . c = [number] + Bar . me [comment] [EOL] self . b = self . c + CONSTANT [comment]",
@@ -3043,6 +3147,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.37
+        "type_annot_cove": 0.38
     }
 }

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -168,8 +168,8 @@
                 "type_annot_cove": 0.0
             },
             "libsa4py/tests/examples/qualified_types.py": {
-                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
+                "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
                     "Dict",
                     "Tuple",
@@ -203,7 +203,13 @@
                     "foo_t": "typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]"
                 },
                 "mod_var_occur": {
-                    "d": [],
+                    "d": [
+                        [
+                            "d",
+                            "Delta",
+                            "Delta"
+                        ]
+                    ],
                     "l": [],
                     "q_v": [],
                     "l_n": [],
@@ -247,6 +253,12 @@
                 },
                 "classes": [
                     {
+                        "name": "Delta",
+                        "variables": {},
+                        "cls_var_occur": {},
+                        "funcs": []
+                    },
+                    {
                         "name": "Foo",
                         "variables": {
                             "foo_seq": "collections.abc.Sequence"
@@ -287,7 +299,8 @@
                                 "ret_type": "",
                                 "variables": {
                                     "x": "typing.Tuple",
-                                    "n": "numpy.int"
+                                    "n": "numpy.int",
+                                    "d": "Delta"
                                 },
                                 "fn_var_occur": {
                                     "x": [
@@ -306,6 +319,13 @@
                                             "int",
                                             "np",
                                             "int"
+                                        ]
+                                    ],
+                                    "d": [
+                                        [
+                                            "d",
+                                            "Delta",
+                                            "Delta"
                                         ]
                                     ]
                                 },
@@ -381,7 +401,7 @@
                 "set": null,
                 "no_types_annot": {
                     "U": 2,
-                    "D": 23,
+                    "D": 24,
                     "I": 0
                 },
                 "type_annot_cove": 0.92

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -16,20 +16,20 @@ class TestAssignments(unittest.TestCase):
         cls.processed_f = Extractor().extract(open('./examples/assignments.py', 'r').read()).to_dict()
 
     def test_module_vars(self):
-        module_vars_expected = {'PI': '', 'M_FOO': '', 'M_BAR': '', 'CONSTANT': 'int', 'LONG_STRING': ''}
+        module_vars_expected = {'PI': '', 'M_FOO': '', 'M_BAR': '', 'CONSTANT': 'builtins.int', 'LONG_STRING': ''}
         self.assertDictEqual(module_vars_expected, self.processed_f['variables'])
 
     def test_class_vars(self):
-        cls_vars_expected = {'x': '', 'u': '', 'f': '', 'out_y': 'str', 'scientific_num': ''}
+        cls_vars_expected = {'x': '', 'u': '', 'f': '', 'out_y': 'builtins.str', 'scientific_num': ''}
         self.assertDictEqual(cls_vars_expected, self.processed_f['classes'][0]['variables'])
 
     def test_self_vars(self):
         # TODO: implement the extraction of self vars in a multiple assignments
-        self_vars_expected = {'x': 'int', 'y': '', 'b': '', 'c': '', 'error': 'List'}
+        self_vars_expected = {'x': 'builtins.int', 'y': '', 'b': '', 'c': '', 'error': 'typing.List'}
         self.assertDictEqual(self_vars_expected, self.processed_f['classes'][0]['funcs'][0]['variables'])
 
     def test_local_vars(self):
-        local_vars_expected = {'f_no': 'float', 'l': 'List[str]', 'foo': 'str'}
+        local_vars_expected = {'f_no': 'builtins.float', 'l': 'typing.List[builtins.str]', 'foo': 'builtins.str'}
         self.assertDictEqual(local_vars_expected, self.processed_f['classes'][0]['funcs'][1]['variables'])
 
     def test_tuple_assign(self):

--- a/tests/test_cst_transformers.py
+++ b/tests/test_cst_transformers.py
@@ -1,3 +1,4 @@
+from libsa4py.cst_lenient_parser import lenient_parse_module
 from libsa4py.cst_visitor import Visitor
 from libsa4py.cst_transformers import SpaceAdder, TypeAdder,\
     CommentAndDocStringRemover, StringRemover, NumberRemover, \
@@ -148,5 +149,15 @@ class TestParametricTypeDepthReducer(unittest.TestCase):
         exp_t = "List[List[Dict[str, Any]]]"
         self.assertEqual(exp_t,
                          self.__reduce_depth_param_type("List[List[Dict[str, Tuple[int]]]]", 3))
+
+    def test_param_type_reduce_lenient_parse(self):
+        param_type = "Dict[str, Type[Union[.vendor.pip._vendor.requests.packages.urllib3.contrib.socks.SOCKSHTTPConnectionPool," \
+                     " .vendor.pip._vendor.requests.packages.urllib3.contrib.socks.SOCKSHTTPSConnectionPool]]]"
+        exp_out = "Dict[str, Type[Any]]"
+
+        t = lenient_parse_module(param_type)
+        t = t.visit(ParametricTypeDepthReducer(2))
+
+        self.assertEqual(t.code, exp_out)
 
 

--- a/tests/test_different_fns.py
+++ b/tests/test_different_fns.py
@@ -18,10 +18,10 @@ class TestDifferentFns(unittest.TestCase):
     def test_typical_fn(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'add'
-        fn_expected['params'] = {'x': 'int', 'y': 'int'}
+        fn_expected['params'] = {'x': 'builtins.int', 'y': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return x + y']
         fn_expected['params_occur'] = {'x': [['x', 'y']], 'y': [['x', 'y']]}
-        fn_expected['ret_type'] = 'int'
+        fn_expected['ret_type'] = 'builtins.int'
         fn_expected['params_descr'] = {'x': '', 'y': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][0])
@@ -30,7 +30,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'noargs'
         fn_expected['ret_exprs'] = ['return 5']
-        fn_expected['ret_type'] = 'int'
+        fn_expected['ret_type'] = 'builtins.int'
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][1])
 
@@ -44,18 +44,16 @@ class TestDifferentFns(unittest.TestCase):
     def test_noreturn(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'noreturn'
-        fn_expected['params'] = {'x': 'int'}
+        fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['params_occur'] = {'x': [['print', 'x']]}
         fn_expected['params_descr'] = {'x': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][3])
 
     def test_return_none(self):
-        print(self.processed_f['funcs'][4])
-
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'return_none'
-        fn_expected['params'] = {'x': 'int'}
+        fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['params_occur'] = {'x': [['print', 'x']]}
         fn_expected['ret_type'] = 'None'
         fn_expected['params_descr'] = {'x': ''}
@@ -65,10 +63,10 @@ class TestDifferentFns(unittest.TestCase):
     def test_return_optional(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'return_optional'
-        fn_expected['params'] = {'y': 'list'}
+        fn_expected['params'] = {'y': 'builtins.list'}
         fn_expected['ret_exprs'] = ['return None', 'return y']
         fn_expected['params_occur'] = {'y': [['len', 'y']]}
-        fn_expected['ret_type'] = 'Optional[int]'
+        fn_expected['ret_type'] = 'typing.Optional[builtins.int]'
         fn_expected['params_descr'] = {'y': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][5])
@@ -79,7 +77,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected['params'] = {'x': '', 'y': ''}
         fn_expected['ret_exprs'] = ['return x + y']
         fn_expected['params_occur'] = {'x': [['x', 'y']], 'y': [['x', 'y']]}
-        fn_expected['ret_type'] = 'int'
+        fn_expected['ret_type'] = 'builtins.int'
         fn_expected['params_descr'] = {'x': '', 'y': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][6])
@@ -87,10 +85,10 @@ class TestDifferentFns(unittest.TestCase):
     def test_inner(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'inner'
-        fn_expected['params'] = {'x': 'int'}
+        fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return 12 + x']
         fn_expected['params_occur'] = {'x': []}
-        fn_expected['ret_type'] = 'int'
+        fn_expected['ret_type'] = 'builtins.int'
         fn_expected['params_descr'] = {'x': ''}
         fn_expected['docstring'] = {'func': 'This is the inner function', 'ret': None, 'long_descr': None}
 
@@ -106,12 +104,12 @@ class TestDifferentFns(unittest.TestCase):
     def test_varargs(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'varargs'
-        fn_expected['params'] = {'xs': 'int'}
+        fn_expected['params'] = {'xs': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return sum']
         fn_expected['params_occur'] = {'xs': []}
-        fn_expected['ret_type'] = 'int'
-        fn_expected['variables'] = {'sum': 'int'}
-        fn_expected['fn_var_occur'] = {'sum': [['sum', 'int'], ['sum', 'x']]}
+        fn_expected['ret_type'] = 'builtins.int'
+        fn_expected['variables'] = {'sum': 'builtins.int'}
+        fn_expected['fn_var_occur'] = {'sum': [['sum', 'builtins', 'int'], ['sum', 'x']]}
         fn_expected['params_descr'] = {'xs': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][9])
@@ -122,9 +120,9 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected['params'] = {'xs': ''}
         fn_expected['ret_exprs'] = ['return sum']
         fn_expected['params_occur'] = {'xs': []}
-        fn_expected['ret_type'] = 'int'
-        fn_expected['variables'] = {'sum': 'int'}
-        fn_expected['fn_var_occur'] = {'sum': [['sum', 'int'], ['sum', 'x']]}
+        fn_expected['ret_type'] = 'builtins.int'
+        fn_expected['variables'] = {'sum': 'builtins.int'}
+        fn_expected['fn_var_occur'] = {'sum': [['sum', 'builtins', 'int'], ['sum', 'x']]}
         fn_expected['params_descr'] = {'xs': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][10])
@@ -132,7 +130,7 @@ class TestDifferentFns(unittest.TestCase):
     def test_kwarg_method(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'kwarg_method'
-        fn_expected['params'] = {'a': 'int', 'b': 'int', 'c': 'float'}
+        fn_expected['params'] = {'a': 'builtins.int', 'b': 'builtins.int', 'c': 'builtins.float'}
         fn_expected['ret_exprs'] = ['return c']
         fn_expected['params_descr'] = {'a': '', 'b': '', 'c': ''}
         fn_expected['params_occur'] = {'a': [], 'b': [], 'c': []}
@@ -142,10 +140,10 @@ class TestDifferentFns(unittest.TestCase):
     def test_async_fn(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'async_fn'
-        fn_expected['params'] = {'y': 'int'}
+        fn_expected['params'] = {'y': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return await y']
         fn_expected['params_occur'] = {'y': []}
-        fn_expected['ret_type'] = 'int'
+        fn_expected['ret_type'] = 'builtins.int'
         fn_expected['params_descr'] = {'y': ''}
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][12])
@@ -153,9 +151,9 @@ class TestDifferentFns(unittest.TestCase):
     def test_abstract_fn(self):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'abstract_fn'
-        fn_expected['params'] = {'name': 'str'}
+        fn_expected['params'] = {'name': 'builtins.str'}
         fn_expected['params_descr'] = {'name': ''}
         fn_expected['params_occur'] = {'name': []}
-        fn_expected['ret_type'] = 'str'
+        fn_expected['ret_type'] = 'builtins.str'
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][13])

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -41,7 +41,7 @@ class TestExtractorPyre(unittest.TestCase):
         """
         Tests whether pyre's inferred types are incorporated into the module output representation
         """
-        exp_mod_vars_types = {"PI": "float", "no": "int", "CONSTANT": "str", "X": "int", "Y": "int"}
+        exp_mod_vars_types = {"PI": "float", "no": "builtins.int", "CONSTANT": "str", "X": "int", "Y": "int"}
         self.assertDictEqual(exp_mod_vars_types, self.extractor_out.to_dict()['variables'])
 
     def test_class_vars_types(self):
@@ -60,12 +60,13 @@ class TestExtractorPyre(unittest.TestCase):
                              self.extractor_out.to_dict()['classes'][0]['funcs'][1]['variables'])
 
     def test_module_seq2seq_repr(self):
-        exp_mod_seq2seq = "0 0 0 $float$ 0 0 0 $int$ 0 0 0 $str$ 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0" \
-                          " $str$ 0 0 0 $int$ 0 $typing.List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" \
-                          " $typing.List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple[typing.Tuple[int,int],str]$" \
-                          " 0 0 0 $typing.Tuple[typing.Tuple[int,int],str]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" \
-                          " $typing.Tuple[typing_extensions.Literal['Hello'],typing_extensions.Literal['World']]$ 0 0 0" \
-                          " 0 0 0 0 $float$ 0 $int$ 0 0 0 0 0 $float$ 0 $float$ 0 $float$ 0 0 0 0"
+        exp_mod_seq2seq = "0 0 0 $float$ 0 0 0 $builtins.int$ 0 0 0 $str$ 0 0 0 $int$ 0 $int$ 0 0 0 0 0 0 0 0 0 0 " \
+                          "$int$ 0 0 0 $str$ 0 0 0 $int$ 0 $typing.List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 " \
+                          "0 0 0 0 0 0 $typing.List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 " \
+                          "$typing.Tuple[typing.Tuple[int,int],str]$ 0 0 0 $typing.Tuple[typing.Tuple[int,int],str]$ 0 " \
+                          "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 " \
+                          "$typing.Tuple[typing_extensions.Literal['Hello'],typing_extensions.Literal['World']]$ 0 0 0 " \
+                          "0 0 0 0 $float$ 0 $int$ 0 0 0 0 0 $float$ 0 $float$ 0 $float$ 0 0 0 0"
 
         self.assertEqual(exp_mod_seq2seq, self.extractor_out.to_dict()['typed_seq'])
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,11 +17,11 @@ class TestPipeline(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         p_nlp = Pipeline(Path(__file__).parent.absolute().parent,
-                         join(Path(__file__).parent.absolute(), 'tmp'), nlp_transf=True)
+                         join(Path(__file__).parent.absolute(), 'tmp'), nlp_transf=True, use_pyre=False)
         p_nlp.run([{'author': 'tests', 'repo': 'examples'}], 1)
 
         p_no_nlp = Pipeline(Path(__file__).parent.absolute().parent,
-                            join(Path(__file__).parent.absolute(), 'tmp_nonlp'), nlp_transf=False)
+                            join(Path(__file__).parent.absolute(), 'tmp_nonlp'), nlp_transf=False, use_pyre=False)
         p_no_nlp.run([{'author': 'tests', 'repo': 'examples'}], 1)
 
     def test_pipeline_output(self):

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -1,0 +1,35 @@
+from libsa4py.cst_extractor import Extractor
+import unittest
+
+
+class TestQualifiedTypes(unittest.TestCase):
+    """
+    It tests resolving qualified type names, e.g. t.List -> typing.List
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.processed_f = Extractor().extract(open('examples/qualified_types.py', 'r').read()).to_dict()
+
+    def test_qualified_type_assign(self):
+        exp_q_type = {'d': 'typing.Dict', 'l': 'typing.List[builtins.str]'}
+        self.assertDictEqual(exp_q_type, self.processed_f['variables'])
+
+    def test_qualified_type_cls_var(self):
+        exp_q_type = {'foo_seq': 'collections.abc.Sequence'}
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['variables'])
+
+    def test_qualified_type_fn_params(self):
+        exp_q_type = {'self': '', 'x': 'typing.Tuple', 'y': 'typing.Pattern'}
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][0]['params'])
+
+    def test_qualified_type_fn_vars(self):
+        exp_q_type = {'x': 'typing.Tuple', 'n': 'numpy.int'}
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][0]['variables'])
+
+    def test_qualified_type_fn_ret(self):
+        exp_q_ret_type = 'numpy.array'
+        self.assertEqual(exp_q_ret_type, self.processed_f['classes'][0]['funcs'][1]['ret_type'])

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -26,7 +26,7 @@ class TestQualifiedTypes(unittest.TestCase):
                       'tqr': 'libsa4py.cst_transformers.TypeQualifierResolver',
                       'lt': 'typing.Literal["123"]',
                       'c_h': 'typing.Callable[[typing.List, typing.Dict], builtins.int]',
-                      's': '[]', 'u': '"Foo"', 'foo': 'Foo',
+                      's': '[]', 'u': '"Foo"', 'foo': 'Foo', 'b': 'True',
                       'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]',
                       'N': 'typing.Union[typing.List, None]',
                       'rl': 'representations.Bar'}

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -28,7 +28,8 @@ class TestQualifiedTypes(unittest.TestCase):
                       'c_h': 'typing.Callable[[typing.List, typing.Dict], builtins.int]',
                       's': '[]', 'u': '"Foo"', 'foo': 'Foo',
                       'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]',
-                      'N': 'typing.Union[typing.List, None]'}
+                      'N': 'typing.Union[typing.List, None]',
+                      'rl': 'representations.Bar'}
 
         self.assertDictEqual(exp_q_type, self.processed_f['variables'])
 
@@ -47,3 +48,7 @@ class TestQualifiedTypes(unittest.TestCase):
     def test_qualified_type_fn_ret(self):
         exp_q_ret_type = 'numpy.array'
         self.assertEqual(exp_q_ret_type, self.processed_f['classes'][0]['funcs'][1]['ret_type'])
+
+    def test_shadowed_qualified_name(self):
+        exp_q_type = {'sq': 'builtins.str'}
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][2]['variables'])

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -29,7 +29,8 @@ class TestQualifiedTypes(unittest.TestCase):
                       's': '[]', 'u': '"Foo"', 'foo': 'Foo', 'b': 'True',
                       'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]',
                       'N': 'typing.Union[typing.List, None]',
-                      'rl': 'representations.Bar'}
+                      'rl': 'representations.Bar',
+                      'relative_i': 'test_imports.TestImports'}
 
         self.assertDictEqual(exp_q_type, self.processed_f['variables'])
 

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -9,13 +9,26 @@ class TestQualifiedTypes(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.maxDiff = None
 
     @classmethod
     def setUpClass(cls):
         cls.processed_f = Extractor().extract(open('examples/qualified_types.py', 'r').read()).to_dict()
 
     def test_qualified_type_assign(self):
-        exp_q_type = {'d': 'typing.Dict', 'l': 'typing.List[builtins.str]'}
+        exp_q_type = {'d': 'typing.Dict', 'l': 'typing.List[builtins.str]',
+                      'l_n': 'typing.List[typing.Tuple[builtins.int, builtins.int]]',
+                      'q_v': 'typing.List[builtins.int]', 't_e': 'typing.Tuple[typing.Any, ...]',
+                      'u_d': 'typing.Union[typing.List[typing.Tuple[builtins.str, builtins.int]], '
+                             'typing.Tuple[typing.Any], typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]',
+                      'c': 'typing.Callable[..., typing.List]',
+                      't_a': 'typing.Type[typing.List]',
+                      'tqr': 'libsa4py.cst_transformers.TypeQualifierResolver',
+                      'lt': 'typing.Literal["123"]',
+                      'c_h': 'typing.Callable[[typing.List, typing.Dict], builtins.int]',
+                      's': '[]', 'u': '"Foo"', 'foo': 'Foo',
+                      'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]'}
+
         self.assertDictEqual(exp_q_type, self.processed_f['variables'])
 
     def test_qualified_type_cls_var(self):

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -35,20 +35,20 @@ class TestQualifiedTypes(unittest.TestCase):
 
     def test_qualified_type_cls_var(self):
         exp_q_type = {'foo_seq': 'collections.abc.Sequence'}
-        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['variables'])
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][1]['variables'])
 
     def test_qualified_type_fn_params(self):
         exp_q_type = {'self': '', 'x': 'typing.Tuple', 'y': 'typing.Pattern'}
-        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][0]['params'])
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][1]['funcs'][0]['params'])
 
     def test_qualified_type_fn_vars(self):
-        exp_q_type = {'x': 'typing.Tuple', 'n': 'numpy.int'}
-        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][0]['variables'])
+        exp_q_type = {'x': 'typing.Tuple', 'n': 'numpy.int', 'd': 'Delta'}
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][1]['funcs'][0]['variables'])
 
     def test_qualified_type_fn_ret(self):
         exp_q_ret_type = 'numpy.array'
-        self.assertEqual(exp_q_ret_type, self.processed_f['classes'][0]['funcs'][1]['ret_type'])
+        self.assertEqual(exp_q_ret_type, self.processed_f['classes'][1]['funcs'][1]['ret_type'])
 
     def test_shadowed_qualified_name(self):
         exp_q_type = {'sq': 'builtins.str'}
-        self.assertDictEqual(exp_q_type, self.processed_f['classes'][0]['funcs'][2]['variables'])
+        self.assertDictEqual(exp_q_type, self.processed_f['classes'][1]['funcs'][2]['variables'])

--- a/tests/test_qualified_types_.py
+++ b/tests/test_qualified_types_.py
@@ -27,7 +27,8 @@ class TestQualifiedTypes(unittest.TestCase):
                       'lt': 'typing.Literal["123"]',
                       'c_h': 'typing.Callable[[typing.List, typing.Dict], builtins.int]',
                       's': '[]', 'u': '"Foo"', 'foo': 'Foo',
-                      'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]'}
+                      'foo_t': 'typing.Tuple[Foo, libsa4py.cst_transformers.TypeQualifierResolver]',
+                      'N': 'typing.Union[typing.List, None]'}
 
         self.assertDictEqual(exp_q_type, self.processed_f['variables'])
 

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -22,19 +22,19 @@ class TestModuleRepresentations(unittest.TestCase):
         self.assertListEqual(mod_repr_dict_key_exp, list(processed_f.to_dict().keys()))
 
     def test_mod_repr_cls_dict(self):
-        cls_repr_mod_exp = [{'name': 'MyClass', 'variables': {'cls_var': 'int'},
+        cls_repr_mod_exp = [{'name': 'MyClass', 'variables': {'cls_var': 'builtins.int'},
                              'cls_var_occur': {'cls_var': [['MyClass', 'cls_var', 'c', 'n']]},
-                             'funcs': [{'name': '__init__', 'params': {'self': '', 'y': 'float'}, 'ret_exprs': [],
+                             'funcs': [{'name': '__init__', 'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
                                         'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                                         'ret_type': 'None', 'variables': {'y': ''},
                                         'fn_var_occur': {'y': [['self', 'y', 'y']]},
                                         'params_descr': {'self': '', 'y': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}},
-                                       {'name': 'cls_fn', 'params': {'self': '', 'c': 'int'},
+                                       {'name': 'cls_fn', 'params': {'self': '', 'c': 'builtins.int'},
                                         'ret_exprs': ['return MyClass.cls_var + c / (2 + n)'],
                                         'params_occur': {'self': [], 'c': [['n', 'c'],
                                                                            ['MyClass', 'cls_var', 'c', 'n']]},
-                                        'ret_type': 'float', 'variables': {'n': ''},
+                                        'ret_type': 'builtins.float', 'variables': {'n': ''},
                                         'fn_var_occur': {'n': [['n', 'c'], ['MyClass', 'cls_var', 'c', 'n']]},
                                         'params_descr': {'self': '', 'c': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}}]},
@@ -47,8 +47,8 @@ class TestModuleRepresentations(unittest.TestCase):
         self.assertListEqual(cls_repr_mod_exp, processed_f.to_dict()['classes'])
 
     def test_mod_repr_fn_dict(self):
-        fn_repr_mod_exp = [{'name': 'my_fn', 'params': {'x': 'int'}, 'ret_exprs': ['return x + 10'],
-                            'params_occur': {'x': []}, 'ret_type': 'int', 'variables': {}, 'fn_var_occur': {},
+        fn_repr_mod_exp = [{'name': 'my_fn', 'params': {'x': 'builtins.int'}, 'ret_exprs': ['return x + 10'],
+                            'params_occur': {'x': []}, 'ret_type': 'builtins.int', 'variables': {}, 'fn_var_occur': {},
                             'params_descr': {'x': ''}, 'docstring': {'func': None, 'ret': None, 'long_descr': None}},
                            {'name': 'foo', 'params': {}, 'ret_exprs': [], 'params_occur': {}, 'ret_type': 'None',
                             'variables': {}, 'fn_var_occur': {}, 'params_descr': {},
@@ -71,9 +71,10 @@ class TestModuleRepresentations(unittest.TestCase):
         self.assertEqual(mod_untyped_seq, processed_f.to_dict()['untyped_seq'])
 
     def test_mod_typed_seq(self):
-        mod_typed_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0" \
-                        " 0 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0" \
-                        " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
+        mod_typed_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 " \
+                        "0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 " \
+                        "0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 " \
+                        "0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
 
         self.assertEqual(mod_typed_seq, processed_f.to_dict()['typed_seq'])
 
@@ -104,15 +105,15 @@ class TestClassRepresentation(unittest.TestCase):
         self.assertEqual(cls_repr_name, processed_f.to_dict()['classes'][0]['name'])
 
     def test_cls_repr_fns_dict(self):
-        fns_repr_cls_exp = [{'name': '__init__', 'params': {'self': '', 'y': 'float'}, 'ret_exprs': [],
+        fns_repr_cls_exp = [{'name': '__init__', 'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
                              'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                              'ret_type': 'None', 'variables': {'y': ''}, 'fn_var_occur': {'y': [['self', 'y', 'y']]},
                              'params_descr': {'self': '', 'y': ''},
                              'docstring': {'func': None, 'ret': None, 'long_descr': None}},
-                            {'name': 'cls_fn', 'params': {'self': '', 'c': 'int'},
+                            {'name': 'cls_fn', 'params': {'self': '', 'c': 'builtins.int'},
                              'ret_exprs': ['return MyClass.cls_var + c / (2 + n)'],
                              'params_occur': {'self': [], 'c': [['n', 'c'], ['MyClass', 'cls_var', 'c', 'n']]},
-                             'ret_type': 'float', 'variables': {'n': ''},
+                             'ret_type': 'builtins.float', 'variables': {'n': ''},
                              'fn_var_occur': {'n': [['n', 'c'], ['MyClass', 'cls_var', 'c', 'n']]},
                              'params_descr': {'self': '', 'c': ''},
                              'docstring': {'func': None, 'ret': None, 'long_descr': None}}]
@@ -141,7 +142,7 @@ class TestFunctionRepresentation(unittest.TestCase):
                              list(processed_f.to_dict()['classes'][0]['funcs'][0]['docstring'].keys()))
 
     def test_fn_repr_dict(self):
-        fn_repr_dict = {'name': '__init__', 'params': {'self': '', 'y': 'float'}, 'ret_exprs': [],
+        fn_repr_dict = {'name': '__init__', 'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
                         'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                         'ret_type': 'None', 'variables': {'y': ''}, 'fn_var_occur': {'y': [['self', 'y', 'y']]},
                         'params_descr': {'self': '', 'y': ''},
@@ -165,34 +166,38 @@ class TestOutputSequence(unittest.TestCase):
                          read_file('exp_outputs/normalized_mod_code.txt').strip())
 
     def test_create_output_sequence(self):
-        exp_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
+        exp_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
 
         self.assertEqual(exp_out_seq, create_output_seq(normalize_module_code(processed_f.typed_seq)))
 
     def test_invalid_type_alignment_with_name(self):
         # Misses one type
-        malformed_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
+        malformed_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
 
         self.assertRaises(OutputSequenceException, validate_output_seq,
                           normalize_module_code(processed_f.typed_seq), malformed_out_seq)
 
     def test_invalid_non_name_alignment(self):
         # Has an extra type
-        malformed_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 $float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
+        malformed_out_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
 
         self.assertRaises(OutputSequenceException, validate_output_seq,
                           normalize_module_code(processed_f.typed_seq), malformed_out_seq)
 
     def test_invalid_input_typed_seq(self):
-        valid_out_typed_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 $float$ 0 0 0 $int$ 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0" \
-                      " 0 0 0 0 0 0 0 0 0 0 0 0 0 $int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
+        valid_out_typed_seq = "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 " \
+                      "0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0"
 
         # Don't have required spaces between tokens
         invalid_in_typed_seq = "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] " \

--- a/tests/test_vars_args_occur.py
+++ b/tests/test_vars_args_occur.py
@@ -1,5 +1,4 @@
 from libsa4py.cst_extractor import Extractor
-from tests.constans import FN_DICT_REPR
 import unittest
 
 
@@ -48,7 +47,7 @@ class TestVarsArgsOccur(unittest.TestCase):
         self.assertDictEqual(cls_vars_use, self.processed_f['classes'][0]['cls_var_occur'])
 
     def test_local_vars_use(self):
-        local_vars_use = {'v': [['v', 'int', 'sum'], ['v_1', 'v', 'p'], ['range', 'v', 'v_1'], ['i', 'v'],
+        local_vars_use = {'v': [['v', 'builtins', 'int', 'sum'], ['v_1', 'v', 'p'], ['range', 'v', 'v_1'], ['i', 'v'],
                                 ['v', 'v_1', 'v'], ['print', 'v'], ['v', 'v_1'], ['print', 'v', 'v_1'],
                                 ['v', 'v_1', 'p'], ['v', 'v_1'], ['v', 'n'], ['v', 'p', 'p']],
                           'v_1': [['v_1', 'v', 'p'], ['range', 'v', 'v_1'], ['i', 'v_1'], ['v', 'v_1', 'v'],


### PR DESCRIPTION
This PR addresses #14. In short, it adds type annotations with a qualified name when processing projects. This makes extracted type annotations consistent for an entire dataset.