### PR TITLE
Add line and column no. for the start and end of functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the [LibSA4Py](https://github.com/saltudelft/libsa4py) to
 - Extracting type annotations with a qualified name from source code files.
 - Adding `apply` command to apply inferred type annotations to source code files.
 - Adding a qualified name for functions in the JSON field `q_name`.
+- Adding line and column no. for the start and end of functions in the JSON field `fn_lc`.
 
 ### Fixed
 - Malformed output sequences containing string literal type, i.e., `Literal['Blah \n blah']`.

--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -90,6 +90,7 @@ class Visitor(cst.CSTVisitor):
         # Decrease stack depth of the current function
         fn = self.stack.pop()
 
+        fn.ln_col = self.__get_line_column_no(fn.node)
         fn.docstring, params_descr = extract_docstring_descriptions(self.__extract_docstring(node))
         fn.params_descr = {p: params_descr[p] if p in params_descr else '' for p in fn.parameters.keys()}
 
@@ -701,3 +702,7 @@ class Visitor(cst.CSTVisitor):
 
         except KeyError:
             return ''
+
+    def __get_line_column_no(self, node) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        lc = self.get_metadata(cst.metadata.PositionProvider, node)
+        return (lc.start.line, lc.start.column), (lc.end.line, lc.end.column)

--- a/libsa4py/representations.py
+++ b/libsa4py/representations.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Pattern, Match
+from typing import Dict, List, Tuple
 from libsa4py.exceptions import OutputSequenceException
 
 import re
@@ -16,6 +16,8 @@ class FunctionInfo:
     def __init__(self, name) -> None:
         self.name = name
         self.q_name = None
+        # Line, Column no. for the start and end of the function
+        self.ln_col: Tuple[Tuple[int, int], Tuple[int, int]] = None
         self.parameters: Dict[str, str] = {}
         self.parameters_occur: Dict[str, list] = {}
         self.params_descr: Dict[str, str] = {}
@@ -27,13 +29,15 @@ class FunctionInfo:
         self.node = None
 
     def to_dict(self):
-        return {"name": self.name, "q_name": self.q_name, "params": self.parameters, "ret_exprs": self.return_exprs,
-                "params_occur": self.parameters_occur, "ret_type": self.return_type, "variables": self.variables,
-                "fn_var_occur": self.variables_occur, "params_descr": self.params_descr, "docstring": self.docstring}
+        return {"name": self.name, "q_name": self.q_name, "fn_lc": self.ln_col, "params": self.parameters,
+                "ret_exprs": self.return_exprs, "params_occur": self.parameters_occur, "ret_type": self.return_type,
+                "variables": self.variables, "fn_var_occur": self.variables_occur, "params_descr": self.params_descr,
+                "docstring": self.docstring}
 
     def from_dict(self, fn_dict_repr: dict):
         self.name = fn_dict_repr['name']
         self.q_name = fn_dict_repr['q_name']
+        self.ln_col = (tuple(fn_dict_repr['fn_lc'][0]), tuple(fn_dict_repr['fn_lc'][1]))
         self.parameters = fn_dict_repr['params']
         self.parameters_occur = fn_dict_repr['params_occur']
         self.params_descr = fn_dict_repr['params_descr']
@@ -48,6 +52,7 @@ class FunctionInfo:
     def __eq__(self, other_func_info_obj: 'FunctionInfo'):
         return other_func_info_obj.name == self.name and \
                other_func_info_obj.q_name == self.q_name and \
+               other_func_info_obj.ln_col == self.ln_col and \
                other_func_info_obj.parameters == self.parameters and \
                other_func_info_obj.parameters_occur == self.parameters_occur and \
                other_func_info_obj.params_descr == self.params_descr and \

--- a/tests/constans.py
+++ b/tests/constans.py
@@ -1,3 +1,3 @@
-FN_DICT_REPR = {'name': '', 'q_name': '', 'params': {}, 'ret_exprs': [], 'params_occur': {}, 'ret_type': '',
+FN_DICT_REPR = {'name': '', 'q_name': '', 'fn_lc': None, 'params': {}, 'ret_exprs': [], 'params_occur': {}, 'ret_type': '',
                 'variables': {}, 'fn_var_occur': {}, 'params_descr': {},
                 'docstring': {'func': None, 'ret': None, 'long_descr': None}}

--- a/tests/examples/different_fns.py
+++ b/tests/examples/different_fns.py
@@ -78,3 +78,8 @@ async def async_fn(y: int) -> int:
 
 # An abstract function with typed args
 def abstract_fn(name: str) -> str: ...
+
+
+# For extracting line and column no. of a function
+def fn_lineno(x):
+    print(x)

--- a/tests/exp_outputs/extractor_out.json
+++ b/tests/exp_outputs/extractor_out.json
@@ -31,6 +31,16 @@
                 {
                     "name": "__init__",
                     "q_name": "MyClass.__init__",
+                    "fn_lc": [
+                        [
+                            18,
+                            4
+                        ],
+                        [
+                            19,
+                            18
+                        ]
+                    ],
                     "params": {
                         "self": "",
                         "y": "builtins.float"
@@ -78,6 +88,16 @@
                 {
                     "name": "cls_fn",
                     "q_name": "MyClass.cls_fn",
+                    "fn_lc": [
+                        [
+                            21,
+                            4
+                        ],
+                        [
+                            23,
+                            44
+                        ]
+                    ],
                     "params": {
                         "self": "",
                         "c": "builtins.int"
@@ -138,6 +158,16 @@
                 {
                     "name": "__init__",
                     "q_name": "Bar.__init__",
+                    "fn_lc": [
+                        [
+                            27,
+                            4
+                        ],
+                        [
+                            28,
+                            12
+                        ]
+                    ],
                     "params": {
                         "self": ""
                     },
@@ -164,6 +194,16 @@
         {
             "name": "my_fn",
             "q_name": "my_fn",
+            "fn_lc": [
+                [
+                    31,
+                    0
+                ],
+                [
+                    32,
+                    17
+                ]
+            ],
             "params": {
                 "x": "builtins.int"
             },
@@ -188,6 +228,16 @@
         {
             "name": "foo",
             "q_name": "foo",
+            "fn_lc": [
+                [
+                    35,
+                    0
+                ],
+                [
+                    39,
+                    16
+                ]
+            ],
             "params": {},
             "ret_exprs": [],
             "params_occur": {},

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -52,6 +52,16 @@
                             {
                                 "name": "bar",
                                 "q_name": "Foo.bar",
+                                "fn_lc": [
+                                    [
+                                        24,
+                                        4
+                                    ],
+                                    [
+                                        29,
+                                        12
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -78,6 +88,16 @@
                     {
                         "name": "delta",
                         "q_name": "delta",
+                        "fn_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                16,
+                                8
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -200,6 +220,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Foo.__init__",
+                                "fn_lc": [
+                                    [
+                                        32,
+                                        4
+                                    ],
+                                    [
+                                        37,
+                                        26
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "typing.Tuple",
@@ -264,6 +294,16 @@
                             {
                                 "name": "bar",
                                 "q_name": "Foo.bar",
+                                "fn_lc": [
+                                    [
+                                        39,
+                                        4
+                                    ],
+                                    [
+                                        40,
+                                        34
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -288,6 +328,16 @@
                             {
                                 "name": "shadow qn",
                                 "q_name": "Foo.shadow_qn",
+                                "fn_lc": [
+                                    [
+                                        42,
+                                        4
+                                    ],
+                                    [
+                                        46,
+                                        22
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -375,6 +425,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        15,
+                                        4
+                                    ],
+                                    [
+                                        17,
+                                        34
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -437,6 +497,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                8,
+                                0
+                            ],
+                            [
+                                10,
+                                23
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -566,6 +636,16 @@
                             {
                                 "name": "init",
                                 "q_name": "TestVarArgOccur.__init__",
+                                "fn_lc": [
+                                    [
+                                        18,
+                                        4
+                                    ],
+                                    [
+                                        20,
+                                        18
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.int",
@@ -623,6 +703,16 @@
                             {
                                 "name": "fn params occur",
                                 "q_name": "TestVarArgOccur.fn_params_occur",
+                                "fn_lc": [
+                                    [
+                                        22,
+                                        4
+                                    ],
+                                    [
+                                        45,
+                                        38
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "param": "builtins.int"
@@ -767,6 +857,16 @@
                             {
                                 "name": "local var usage",
                                 "q_name": "TestVarArgOccur.local_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        47,
+                                        4
+                                    ],
+                                    [
+                                        69,
+                                        29
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "p": ""
@@ -872,6 +972,16 @@
                             {
                                 "name": "class var usage",
                                 "q_name": "TestVarArgOccur.class_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        72,
+                                        4
+                                    ],
+                                    [
+                                        89,
+                                        47
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -921,6 +1031,16 @@
                             {
                                 "name": "module var usage",
                                 "q_name": "TestVarArgOccur.module_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        92,
+                                        4
+                                    ],
+                                    [
+                                        103,
+                                        20
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "add something": ""
@@ -973,6 +1093,16 @@
                             {
                                 "name": "format str",
                                 "q_name": "TestVarArgOccur.formatted_str",
+                                "fn_lc": [
+                                    [
+                                        105,
+                                        4
+                                    ],
+                                    [
+                                        108,
+                                        63
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "p": ""
@@ -1055,6 +1185,16 @@
                     {
                         "name": "basic docstring",
                         "q_name": "basic_docstring",
+                        "fn_lc": [
+                            [
+                                1,
+                                0
+                            ],
+                            [
+                                3,
+                                8
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -1071,6 +1211,16 @@
                     {
                         "name": "google docstring",
                         "q_name": "google_docstring",
+                        "fn_lc": [
+                            [
+                                7,
+                                0
+                            ],
+                            [
+                                22,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param": ""
                         },
@@ -1105,6 +1255,16 @@
                     {
                         "name": "rest docstring",
                         "q_name": "rest_docstring",
+                        "fn_lc": [
+                            [
+                                26,
+                                0
+                            ],
+                            [
+                                41,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param": ""
                         },
@@ -1139,6 +1299,16 @@
                     {
                         "name": "numpy docstring",
                         "q_name": "numpy_docstring",
+                        "fn_lc": [
+                            [
+                                45,
+                                0
+                            ],
+                            [
+                                75,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param": ""
                         },
@@ -1173,6 +1343,16 @@
                     {
                         "name": "no docstring",
                         "q_name": "no_docstring",
+                        "fn_lc": [
+                            [
+                                79,
+                                0
+                            ],
+                            [
+                                80,
+                                15
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "none"
@@ -1214,6 +1394,16 @@
                     {
                         "name": "inner import",
                         "q_name": "inner_imports",
+                        "fn_lc": [
+                            [
+                                11,
+                                0
+                            ],
+                            [
+                                13,
+                                25
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -1261,6 +1451,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        13,
+                                        4
+                                    ],
+                                    [
+                                        15,
+                                        28
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.float"
@@ -1323,6 +1523,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                8,
+                                0
+                            ],
+                            [
+                                9,
+                                15
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int",
                             "l": "builtins.list"
@@ -1403,6 +1613,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Test.__init__",
+                                "fn_lc": [
+                                    [
+                                        23,
+                                        4
+                                    ],
+                                    [
+                                        27,
+                                        31
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.int"
@@ -1486,6 +1706,16 @@
                             {
                                 "name": "local var assings",
                                 "q_name": "Test.local_var_assings",
+                                "fn_lc": [
+                                    [
+                                        29,
+                                        4
+                                    ],
+                                    [
+                                        32,
+                                        25
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1530,6 +1760,16 @@
                             {
                                 "name": "tuple assigns",
                                 "q_name": "Test.tuple_assigns",
+                                "fn_lc": [
+                                    [
+                                        34,
+                                        4
+                                    ],
+                                    [
+                                        37,
+                                        49
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1680,6 +1920,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Foo.__init__",
+                                "fn_lc": [
+                                    [
+                                        15,
+                                        4
+                                    ],
+                                    [
+                                        18,
+                                        43
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "t": ""
@@ -1746,6 +1996,16 @@
                             {
                                 "name": "local var",
                                 "q_name": "Foo.local_vars",
+                                "fn_lc": [
+                                    [
+                                        20,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        20
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1856,6 +2116,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Delta.__init__",
+                                "fn_lc": [
+                                    [
+                                        22,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        24
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1892,6 +2162,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                25,
+                                0
+                            ],
+                            [
+                                43,
+                                17
+                            ]
+                        ],
                         "params": {
                             "x": "",
                             "y": "",
@@ -2011,6 +2291,16 @@
                     {
                         "name": "bar",
                         "q_name": "bar",
+                        "fn_lc": [
+                            [
+                                46,
+                                0
+                            ],
+                            [
+                                59,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2068,8 +2358,8 @@
                 "type_annot_cove": 0.24
             },
             "libsa4py/tests/examples/different_fns.py": {
-                "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0",
+                "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL] [EOL] [EOL] [comment] [EOL] def fn_lineno ( x ) : [EOL] print ( x )",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "Optional"
                 ],
@@ -2080,6 +2370,16 @@
                     {
                         "name": "add",
                         "q_name": "add",
+                        "fn_lc": [
+                            [
+                                9,
+                                0
+                            ],
+                            [
+                                10,
+                                16
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int",
                             "y": "builtins.int"
@@ -2113,6 +2413,16 @@
                     {
                         "name": "noargs",
                         "q_name": "noargs",
+                        "fn_lc": [
+                            [
+                                14,
+                                0
+                            ],
+                            [
+                                15,
+                                12
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             ""
@@ -2131,6 +2441,16 @@
                     {
                         "name": "no params",
                         "q_name": "no_params",
+                        "fn_lc": [
+                            [
+                                19,
+                                0
+                            ],
+                            [
+                                20,
+                                12
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             ""
@@ -2149,6 +2469,16 @@
                     {
                         "name": "noreturn",
                         "q_name": "noreturn",
+                        "fn_lc": [
+                            [
+                                24,
+                                0
+                            ],
+                            [
+                                25,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2174,6 +2504,16 @@
                     {
                         "name": "return none",
                         "q_name": "return_none",
+                        "fn_lc": [
+                            [
+                                29,
+                                0
+                            ],
+                            [
+                                30,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2199,6 +2539,16 @@
                     {
                         "name": "return optional",
                         "q_name": "return_optional",
+                        "fn_lc": [
+                            [
+                                34,
+                                0
+                            ],
+                            [
+                                37,
+                                12
+                            ]
+                        ],
                         "params": {
                             "y": "builtins.list"
                         },
@@ -2227,6 +2577,16 @@
                     {
                         "name": "untyped args",
                         "q_name": "untyped_args",
+                        "fn_lc": [
+                            [
+                                41,
+                                0
+                            ],
+                            [
+                                42,
+                                16
+                            ]
+                        ],
                         "params": {
                             "x": "",
                             "y": ""
@@ -2260,6 +2620,16 @@
                     {
                         "name": "inner",
                         "q_name": "with_inner.<locals>.inner",
+                        "fn_lc": [
+                            [
+                                47,
+                                4
+                            ],
+                            [
+                                49,
+                                21
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2284,6 +2654,16 @@
                     {
                         "name": "with inner",
                         "q_name": "with_inner",
+                        "fn_lc": [
+                            [
+                                46,
+                                0
+                            ],
+                            [
+                                50,
+                                20
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "inner"
@@ -2302,6 +2682,16 @@
                     {
                         "name": "varargs",
                         "q_name": "varargs",
+                        "fn_lc": [
+                            [
+                                54,
+                                0
+                            ],
+                            [
+                                58,
+                                14
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2336,6 +2726,16 @@
                     {
                         "name": "untyped varargs",
                         "q_name": "untyped_varargs",
+                        "fn_lc": [
+                            [
+                                62,
+                                0
+                            ],
+                            [
+                                66,
+                                14
+                            ]
+                        ],
                         "params": {
                             "x": ""
                         },
@@ -2370,6 +2770,16 @@
                     {
                         "name": "kwarg method",
                         "q_name": "kwarg_method",
+                        "fn_lc": [
+                            [
+                                70,
+                                0
+                            ],
+                            [
+                                71,
+                                12
+                            ]
+                        ],
                         "params": {
                             "a": "builtins.int",
                             "b": "builtins.int",
@@ -2400,6 +2810,16 @@
                     {
                         "name": "async fn",
                         "q_name": "async_fn",
+                        "fn_lc": [
+                            [
+                                75,
+                                0
+                            ],
+                            [
+                                76,
+                                18
+                            ]
+                        ],
                         "params": {
                             "y": "builtins.int"
                         },
@@ -2424,6 +2844,16 @@
                     {
                         "name": "abstract fn",
                         "q_name": "abstract_fn",
+                        "fn_lc": [
+                            [
+                                80,
+                                0
+                            ],
+                            [
+                                80,
+                                56
+                            ]
+                        ],
                         "params": {
                             "name": "builtins.str"
                         },
@@ -2442,15 +2872,50 @@
                             "ret": null,
                             "long_descr": null
                         }
+                    },
+                    {
+                        "name": "fn lineno",
+                        "q_name": "fn_lineno",
+                        "fn_lc": [
+                            [
+                                84,
+                                0
+                            ],
+                            [
+                                85,
+                                12
+                            ]
+                        ],
+                        "params": {
+                            "x": ""
+                        },
+                        "ret_exprs": [],
+                        "params_occur": {
+                            "x": [
+                                "print",
+                                "x"
+                            ]
+                        },
+                        "ret_type": "",
+                        "variables": {},
+                        "fn_var_occur": {},
+                        "params_descr": {
+                            "x": ""
+                        },
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
                     }
                 ],
                 "set": null,
                 "no_types_annot": {
-                    "U": 7,
+                    "U": 9,
                     "D": 24,
                     "I": 0
                 },
-                "type_annot_cove": 0.77
+                "type_annot_cove": 0.73
             },
             "libsa4py/tests/examples/representations.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
@@ -2483,6 +2948,16 @@
                             {
                                 "name": "init",
                                 "q_name": "MyClass.__init__",
+                                "fn_lc": [
+                                    [
+                                        18,
+                                        4
+                                    ],
+                                    [
+                                        19,
+                                        18
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "y": "builtins.float"
@@ -2524,6 +2999,16 @@
                             {
                                 "name": "cl fn",
                                 "q_name": "MyClass.cls_fn",
+                                "fn_lc": [
+                                    [
+                                        21,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        44
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "c": "builtins.int"
@@ -2576,6 +3061,16 @@
                             {
                                 "name": "init",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        27,
+                                        4
+                                    ],
+                                    [
+                                        28,
+                                        12
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -2602,6 +3097,16 @@
                     {
                         "name": "my fn",
                         "q_name": "my_fn",
+                        "fn_lc": [
+                            [
+                                31,
+                                0
+                            ],
+                            [
+                                32,
+                                17
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2626,6 +3131,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                35,
+                                0
+                            ],
+                            [
+                                39,
+                                16
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -52,6 +52,16 @@
                             {
                                 "name": "bar",
                                 "q_name": "Foo.bar",
+                                "fn_lc": [
+                                    [
+                                        24,
+                                        4
+                                    ],
+                                    [
+                                        29,
+                                        12
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -78,6 +88,16 @@
                     {
                         "name": "delta",
                         "q_name": "delta",
+                        "fn_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                16,
+                                8
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -208,6 +228,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Foo.__init__",
+                                "fn_lc": [
+                                    [
+                                        32,
+                                        4
+                                    ],
+                                    [
+                                        37,
+                                        26
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "typing.Tuple",
@@ -282,6 +312,16 @@
                             {
                                 "name": "bar",
                                 "q_name": "Foo.bar",
+                                "fn_lc": [
+                                    [
+                                        39,
+                                        4
+                                    ],
+                                    [
+                                        40,
+                                        34
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -306,6 +346,16 @@
                             {
                                 "name": "shadow_qn",
                                 "q_name": "Foo.shadow_qn",
+                                "fn_lc": [
+                                    [
+                                        42,
+                                        4
+                                    ],
+                                    [
+                                        46,
+                                        22
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -405,6 +455,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        15,
+                                        4
+                                    ],
+                                    [
+                                        17,
+                                        34
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -477,6 +537,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                8,
+                                0
+                            ],
+                            [
+                                10,
+                                23
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -646,6 +716,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "TestVarArgOccur.__init__",
+                                "fn_lc": [
+                                    [
+                                        18,
+                                        4
+                                    ],
+                                    [
+                                        20,
+                                        18
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.int",
@@ -715,6 +795,16 @@
                             {
                                 "name": "fn_params_occur",
                                 "q_name": "TestVarArgOccur.fn_params_occur",
+                                "fn_lc": [
+                                    [
+                                        22,
+                                        4
+                                    ],
+                                    [
+                                        45,
+                                        38
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "param1": "builtins.int",
@@ -921,6 +1011,16 @@
                             {
                                 "name": "local_vars_usage",
                                 "q_name": "TestVarArgOccur.local_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        47,
+                                        4
+                                    ],
+                                    [
+                                        69,
+                                        29
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "p": ""
@@ -1079,6 +1179,16 @@
                             {
                                 "name": "class_vars_usage",
                                 "q_name": "TestVarArgOccur.class_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        72,
+                                        4
+                                    ],
+                                    [
+                                        89,
+                                        47
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1138,6 +1248,16 @@
                             {
                                 "name": "module_vars_usage",
                                 "q_name": "TestVarArgOccur.module_vars_usage",
+                                "fn_lc": [
+                                    [
+                                        92,
+                                        4
+                                    ],
+                                    [
+                                        103,
+                                        20
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "add_something": ""
@@ -1206,6 +1326,16 @@
                             {
                                 "name": "formatted_str",
                                 "q_name": "TestVarArgOccur.formatted_str",
+                                "fn_lc": [
+                                    [
+                                        105,
+                                        4
+                                    ],
+                                    [
+                                        108,
+                                        63
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "p": ""
@@ -1294,6 +1424,16 @@
                     {
                         "name": "basic_docstring",
                         "q_name": "basic_docstring",
+                        "fn_lc": [
+                            [
+                                1,
+                                0
+                            ],
+                            [
+                                3,
+                                8
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -1310,6 +1450,16 @@
                     {
                         "name": "google_docstring",
                         "q_name": "google_docstring",
+                        "fn_lc": [
+                            [
+                                7,
+                                0
+                            ],
+                            [
+                                22,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param1": "",
                             "param2": ""
@@ -1350,6 +1500,16 @@
                     {
                         "name": "rest_docstring",
                         "q_name": "rest_docstring",
+                        "fn_lc": [
+                            [
+                                26,
+                                0
+                            ],
+                            [
+                                41,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param1": "",
                             "param2": ""
@@ -1390,6 +1550,16 @@
                     {
                         "name": "numpy_docstring",
                         "q_name": "numpy_docstring",
+                        "fn_lc": [
+                            [
+                                45,
+                                0
+                            ],
+                            [
+                                75,
+                                20
+                            ]
+                        ],
                         "params": {
                             "param1": "",
                             "param2": ""
@@ -1430,6 +1600,16 @@
                     {
                         "name": "no_docstring",
                         "q_name": "no_docstring",
+                        "fn_lc": [
+                            [
+                                79,
+                                0
+                            ],
+                            [
+                                80,
+                                15
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "return None"
@@ -1471,6 +1651,16 @@
                     {
                         "name": "inner_imports",
                         "q_name": "inner_imports",
+                        "fn_lc": [
+                            [
+                                11,
+                                0
+                            ],
+                            [
+                                13,
+                                25
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},
@@ -1518,6 +1708,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        13,
+                                        4
+                                    ],
+                                    [
+                                        15,
+                                        28
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.float"
@@ -1590,6 +1790,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                8,
+                                0
+                            ],
+                            [
+                                9,
+                                15
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int",
                             "l": "builtins.list"
@@ -1674,6 +1884,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Test.__init__",
+                                "fn_lc": [
+                                    [
+                                        23,
+                                        4
+                                    ],
+                                    [
+                                        27,
+                                        31
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "x": "builtins.int"
@@ -1777,6 +1997,16 @@
                             {
                                 "name": "local_var_assings",
                                 "q_name": "Test.local_var_assings",
+                                "fn_lc": [
+                                    [
+                                        29,
+                                        4
+                                    ],
+                                    [
+                                        32,
+                                        25
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -1827,6 +2057,16 @@
                             {
                                 "name": "tuple_assigns",
                                 "q_name": "Test.tuple_assigns",
+                                "fn_lc": [
+                                    [
+                                        34,
+                                        4
+                                    ],
+                                    [
+                                        37,
+                                        49
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -2001,6 +2241,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Foo.__init__",
+                                "fn_lc": [
+                                    [
+                                        15,
+                                        4
+                                    ],
+                                    [
+                                        18,
+                                        43
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "t": ""
@@ -2083,6 +2333,16 @@
                             {
                                 "name": "local_vars",
                                 "q_name": "Foo.local_vars",
+                                "fn_lc": [
+                                    [
+                                        20,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        20
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -2217,6 +2477,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Delta.__init__",
+                                "fn_lc": [
+                                    [
+                                        22,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        24
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -2257,6 +2527,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                25,
+                                0
+                            ],
+                            [
+                                43,
+                                17
+                            ]
+                        ],
                         "params": {
                             "x": "",
                             "y": "",
@@ -2432,6 +2712,16 @@
                     {
                         "name": "bar",
                         "q_name": "bar",
+                        "fn_lc": [
+                            [
+                                46,
+                                0
+                            ],
+                            [
+                                59,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2503,8 +2793,8 @@
                 "type_annot_cove": 0.24
             },
             "libsa4py/tests/examples/different_fns.py": {
-                "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL]",
-                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0",
+                "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL] [EOL] [EOL] [comment] [EOL] def fn_lineno ( x ) : [EOL] print ( x )",
+                "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
                     "Optional"
                 ],
@@ -2515,6 +2805,16 @@
                     {
                         "name": "add",
                         "q_name": "add",
+                        "fn_lc": [
+                            [
+                                9,
+                                0
+                            ],
+                            [
+                                10,
+                                16
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int",
                             "y": "builtins.int"
@@ -2552,6 +2852,16 @@
                     {
                         "name": "noargs",
                         "q_name": "noargs",
+                        "fn_lc": [
+                            [
+                                14,
+                                0
+                            ],
+                            [
+                                15,
+                                12
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "return 5"
@@ -2570,6 +2880,16 @@
                     {
                         "name": "no_params",
                         "q_name": "no_params",
+                        "fn_lc": [
+                            [
+                                19,
+                                0
+                            ],
+                            [
+                                20,
+                                12
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "return 0"
@@ -2588,6 +2908,16 @@
                     {
                         "name": "noreturn",
                         "q_name": "noreturn",
+                        "fn_lc": [
+                            [
+                                24,
+                                0
+                            ],
+                            [
+                                25,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2615,6 +2945,16 @@
                     {
                         "name": "return_none",
                         "q_name": "return_none",
+                        "fn_lc": [
+                            [
+                                29,
+                                0
+                            ],
+                            [
+                                30,
+                                12
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2642,6 +2982,16 @@
                     {
                         "name": "return_optional",
                         "q_name": "return_optional",
+                        "fn_lc": [
+                            [
+                                34,
+                                0
+                            ],
+                            [
+                                37,
+                                12
+                            ]
+                        ],
                         "params": {
                             "y": "builtins.list"
                         },
@@ -2672,6 +3022,16 @@
                     {
                         "name": "untyped_args",
                         "q_name": "untyped_args",
+                        "fn_lc": [
+                            [
+                                41,
+                                0
+                            ],
+                            [
+                                42,
+                                16
+                            ]
+                        ],
                         "params": {
                             "x": "",
                             "y": ""
@@ -2709,6 +3069,16 @@
                     {
                         "name": "inner",
                         "q_name": "with_inner.<locals>.inner",
+                        "fn_lc": [
+                            [
+                                47,
+                                4
+                            ],
+                            [
+                                49,
+                                21
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -2733,6 +3103,16 @@
                     {
                         "name": "with_inner",
                         "q_name": "with_inner",
+                        "fn_lc": [
+                            [
+                                46,
+                                0
+                            ],
+                            [
+                                50,
+                                20
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [
                             "return inner(10)"
@@ -2751,6 +3131,16 @@
                     {
                         "name": "varargs",
                         "q_name": "varargs",
+                        "fn_lc": [
+                            [
+                                54,
+                                0
+                            ],
+                            [
+                                58,
+                                14
+                            ]
+                        ],
                         "params": {
                             "xs": "builtins.int"
                         },
@@ -2789,6 +3179,16 @@
                     {
                         "name": "untyped_varargs",
                         "q_name": "untyped_varargs",
+                        "fn_lc": [
+                            [
+                                62,
+                                0
+                            ],
+                            [
+                                66,
+                                14
+                            ]
+                        ],
                         "params": {
                             "xs": ""
                         },
@@ -2827,6 +3227,16 @@
                     {
                         "name": "kwarg_method",
                         "q_name": "kwarg_method",
+                        "fn_lc": [
+                            [
+                                70,
+                                0
+                            ],
+                            [
+                                71,
+                                12
+                            ]
+                        ],
                         "params": {
                             "a": "builtins.int",
                             "b": "builtins.int",
@@ -2857,6 +3267,16 @@
                     {
                         "name": "async_fn",
                         "q_name": "async_fn",
+                        "fn_lc": [
+                            [
+                                75,
+                                0
+                            ],
+                            [
+                                76,
+                                18
+                            ]
+                        ],
                         "params": {
                             "y": "builtins.int"
                         },
@@ -2881,6 +3301,16 @@
                     {
                         "name": "abstract_fn",
                         "q_name": "abstract_fn",
+                        "fn_lc": [
+                            [
+                                80,
+                                0
+                            ],
+                            [
+                                80,
+                                56
+                            ]
+                        ],
                         "params": {
                             "name": "builtins.str"
                         },
@@ -2899,15 +3329,52 @@
                             "ret": null,
                             "long_descr": null
                         }
+                    },
+                    {
+                        "name": "fn_lineno",
+                        "q_name": "fn_lineno",
+                        "fn_lc": [
+                            [
+                                84,
+                                0
+                            ],
+                            [
+                                85,
+                                12
+                            ]
+                        ],
+                        "params": {
+                            "x": ""
+                        },
+                        "ret_exprs": [],
+                        "params_occur": {
+                            "x": [
+                                [
+                                    "print",
+                                    "x"
+                                ]
+                            ]
+                        },
+                        "ret_type": "",
+                        "variables": {},
+                        "fn_var_occur": {},
+                        "params_descr": {
+                            "x": ""
+                        },
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
                     }
                 ],
                 "set": null,
                 "no_types_annot": {
-                    "U": 7,
+                    "U": 9,
                     "D": 24,
                     "I": 0
                 },
-                "type_annot_cove": 0.77
+                "type_annot_cove": 0.73
             },
             "libsa4py/tests/examples/representations.py": {
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
@@ -2942,6 +3409,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "MyClass.__init__",
+                                "fn_lc": [
+                                    [
+                                        18,
+                                        4
+                                    ],
+                                    [
+                                        19,
+                                        18
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "y": "builtins.float"
@@ -2989,6 +3466,16 @@
                             {
                                 "name": "cls_fn",
                                 "q_name": "MyClass.cls_fn",
+                                "fn_lc": [
+                                    [
+                                        21,
+                                        4
+                                    ],
+                                    [
+                                        23,
+                                        44
+                                    ]
+                                ],
                                 "params": {
                                     "self": "",
                                     "c": "builtins.int"
@@ -3049,6 +3536,16 @@
                             {
                                 "name": "__init__",
                                 "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        27,
+                                        4
+                                    ],
+                                    [
+                                        28,
+                                        12
+                                    ]
+                                ],
                                 "params": {
                                     "self": ""
                                 },
@@ -3075,6 +3572,16 @@
                     {
                         "name": "my_fn",
                         "q_name": "my_fn",
+                        "fn_lc": [
+                            [
+                                31,
+                                0
+                            ],
+                            [
+                                32,
+                                17
+                            ]
+                        ],
                         "params": {
                             "x": "builtins.int"
                         },
@@ -3099,6 +3606,16 @@
                     {
                         "name": "foo",
                         "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                35,
+                                0
+                            ],
+                            [
+                                39,
+                                16
+                            ]
+                        ],
                         "params": {},
                         "ret_exprs": [],
                         "params_occur": {},

--- a/tests/test_different_fns.py
+++ b/tests/test_different_fns.py
@@ -19,6 +19,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'add'
         fn_expected['q_name'] = 'add'
+        fn_expected['fn_lc'] = ((9, 0), (10, 16))
         fn_expected['params'] = {'x': 'builtins.int', 'y': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return x + y']
         fn_expected['params_occur'] = {'x': [['x', 'y']], 'y': [['x', 'y']]}
@@ -31,6 +32,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'noargs'
         fn_expected['q_name'] = 'noargs'
+        fn_expected['fn_lc'] = ((14, 0), (15, 12))
         fn_expected['ret_exprs'] = ['return 5']
         fn_expected['ret_type'] = 'builtins.int'
 
@@ -40,6 +42,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'no_params'
         fn_expected['q_name'] = 'no_params'
+        fn_expected['fn_lc'] = ((19, 0), (20, 12))
         fn_expected['ret_exprs'] = ['return 0']
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][2])
@@ -48,6 +51,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'noreturn'
         fn_expected['q_name'] = 'noreturn'
+        fn_expected['fn_lc'] = ((24, 0), (25, 12))
         fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['params_occur'] = {'x': [['print', 'x']]}
         fn_expected['params_descr'] = {'x': ''}
@@ -58,6 +62,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'return_none'
         fn_expected['q_name'] = 'return_none'
+        fn_expected['fn_lc'] = ((29, 0), (30, 12))
         fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['params_occur'] = {'x': [['print', 'x']]}
         fn_expected['ret_type'] = 'None'
@@ -69,6 +74,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'return_optional'
         fn_expected['q_name'] = 'return_optional'
+        fn_expected['fn_lc'] = ((34, 0), (37, 12))
         fn_expected['params'] = {'y': 'builtins.list'}
         fn_expected['ret_exprs'] = ['return None', 'return y']
         fn_expected['params_occur'] = {'y': [['len', 'y']]}
@@ -81,6 +87,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'untyped_args'
         fn_expected['q_name'] = 'untyped_args'
+        fn_expected['fn_lc'] = ((41, 0), (42, 16))
         fn_expected['params'] = {'x': '', 'y': ''}
         fn_expected['ret_exprs'] = ['return x + y']
         fn_expected['params_occur'] = {'x': [['x', 'y']], 'y': [['x', 'y']]}
@@ -93,6 +100,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'inner'
         fn_expected['q_name'] = 'with_inner.<locals>.inner'
+        fn_expected['fn_lc'] = ((47, 4), (49, 21))
         fn_expected['params'] = {'x': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return 12 + x']
         fn_expected['params_occur'] = {'x': []}
@@ -106,6 +114,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'with_inner'
         fn_expected['q_name'] = 'with_inner'
+        fn_expected['fn_lc'] = ((46, 0), (50, 20))
         fn_expected['ret_exprs'] = ['return inner(10)']
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][8])
@@ -114,6 +123,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'varargs'
         fn_expected['q_name'] = 'varargs'
+        fn_expected['fn_lc'] = ((54, 0), (58, 14))
         fn_expected['params'] = {'xs': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return sum']
         fn_expected['params_occur'] = {'xs': []}
@@ -128,6 +138,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'untyped_varargs'
         fn_expected['q_name'] = 'untyped_varargs'
+        fn_expected['fn_lc'] = ((62, 0), (66, 14))
         fn_expected['params'] = {'xs': ''}
         fn_expected['ret_exprs'] = ['return sum']
         fn_expected['params_occur'] = {'xs': []}
@@ -142,6 +153,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'kwarg_method'
         fn_expected['q_name'] = 'kwarg_method'
+        fn_expected['fn_lc'] = ((70, 0), (71, 12))
         fn_expected['params'] = {'a': 'builtins.int', 'b': 'builtins.int', 'c': 'builtins.float'}
         fn_expected['ret_exprs'] = ['return c']
         fn_expected['params_descr'] = {'a': '', 'b': '', 'c': ''}
@@ -153,6 +165,7 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'async_fn'
         fn_expected['q_name'] = 'async_fn'
+        fn_expected['fn_lc'] = ((75, 0), (76, 18))
         fn_expected['params'] = {'y': 'builtins.int'}
         fn_expected['ret_exprs'] = ['return await y']
         fn_expected['params_occur'] = {'y': []}
@@ -165,9 +178,22 @@ class TestDifferentFns(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'abstract_fn'
         fn_expected['q_name'] = 'abstract_fn'
+        fn_expected['fn_lc'] = ((80, 0), (80, 56))
         fn_expected['params'] = {'name': 'builtins.str'}
         fn_expected['params_descr'] = {'name': ''}
         fn_expected['params_occur'] = {'name': []}
         fn_expected['ret_type'] = 'builtins.str'
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][13])
+
+    def test_fn_lineno(self):
+        fn_expected = FN_DICT_REPR.copy()
+        fn_expected['name'] = 'fn_lineno'
+        fn_expected['q_name'] = 'fn_lineno'
+        fn_expected['fn_lc'] = ((84, 0), (85, 12))
+        fn_expected['params'] = {'x': ''}
+        fn_expected['params_descr'] = {'x': ''}
+        fn_expected['params_occur'] = {'x': [['print', 'x']]}
+        fn_expected['ret_type'] = ''
+
+        self.assertDictEqual(fn_expected, self.processed_f['funcs'][14])

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -19,6 +19,7 @@ class TestDocstrings(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'basic_docstring'
         fn_expected['q_name'] = 'basic_docstring'
+        fn_expected['fn_lc'] = ((1, 0), (3, 8))
         fn_expected['docstring']['func'] = 'This is a basic docstring'
 
         self.assertDictEqual(fn_expected, self.processed_f['funcs'][0])
@@ -27,6 +28,7 @@ class TestDocstrings(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'google_docstring'
         fn_expected['q_name'] = 'google_docstring'
+        fn_expected['fn_lc'] = ((7, 0), (22, 20))
         fn_expected['params'] = {'param1': '', 'param2': ''}
         fn_expected['ret_exprs'] = ['return True', 'return False']
         fn_expected['params_occur'] = {'param1': [['len', 'param2', 'param1']], 'param2': [['len', 'param2', 'param1']]}
@@ -40,6 +42,7 @@ class TestDocstrings(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'rest_docstring'
         fn_expected['q_name'] = 'rest_docstring'
+        fn_expected['fn_lc'] = ((26, 0), (41, 20))
         fn_expected['params'] = {'param1': '', 'param2': ''}
         fn_expected['ret_exprs'] = ['return True', 'return False']
         fn_expected['params_occur'] = {'param1': [['len', 'param2', 'param1']], 'param2': [['len', 'param2', 'param1']]}
@@ -53,6 +56,7 @@ class TestDocstrings(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'numpy_docstring'
         fn_expected['q_name'] = 'numpy_docstring'
+        fn_expected['fn_lc'] = ((45, 0), (75, 20))
         fn_expected['params'] = {'param1': '', 'param2': ''}
         fn_expected['ret_exprs'] = ['return True', 'return False']
         fn_expected['params_occur'] = {'param1': [['len', 'param2', 'param1']], 'param2': [['len', 'param2', 'param1']]}
@@ -67,5 +71,6 @@ class TestDocstrings(unittest.TestCase):
         fn_expected = FN_DICT_REPR.copy()
         fn_expected['name'] = 'no_docstring'
         fn_expected['q_name'] = 'no_docstring'
+        fn_expected['fn_lc'] = ((79, 0), (80, 15))
         fn_expected['ret_exprs'] = ['return None']
         fn_expected['docstring'] = {'func': None, 'ret': None, 'long_descr': None}

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -12,13 +12,16 @@ class TestExtractor(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.maxDiff = None
 
     @classmethod
     def setUpClass(cls):
         cls.extractor_out = Extractor().extract(read_file('./examples/representations.py'))
 
     def test_extractor_output(self):
+        #save_json('./exp_outputs/extractor_out.json', self.extractor_out.to_dict())
         expected_out = load_json('./exp_outputs/extractor_out.json')
+
         expected_out = ModuleInfo.from_dict(expected_out)
 
         self.assertEqual(expected_out, self.extractor_out)

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -15,6 +15,7 @@ class TestModuleRepresentations(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.maxDiff = None
 
     def test_mod_repr_dict_keys(self):
         mod_repr_dict_key_exp = ['untyped_seq', 'typed_seq', 'imports', 'variables', 'mod_var_occur', 'classes', 'funcs',
@@ -24,14 +25,14 @@ class TestModuleRepresentations(unittest.TestCase):
     def test_mod_repr_cls_dict(self):
         cls_repr_mod_exp = [{'name': 'MyClass', 'variables': {'cls_var': 'builtins.int'},
                              'cls_var_occur': {'cls_var': [['MyClass', 'cls_var', 'c', 'n']]},
-                             'funcs': [{'name': '__init__', 'q_name': 'MyClass.__init__',
+                             'funcs': [{'name': '__init__', 'q_name': 'MyClass.__init__', 'fn_lc': ((18, 4), (19, 18)),
                                         'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
                                         'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                                         'ret_type': 'None', 'variables': {'y': ''},
                                         'fn_var_occur': {'y': [['self', 'y', 'y']]},
                                         'params_descr': {'self': '', 'y': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}},
-                                       {'name': 'cls_fn', 'q_name': 'MyClass.cls_fn',
+                                       {'name': 'cls_fn', 'q_name': 'MyClass.cls_fn', 'fn_lc': ((21, 4), (23, 44)),
                                         'params': {'self': '', 'c': 'builtins.int'},
                                         'ret_exprs': ['return MyClass.cls_var + c / (2 + n)'],
                                         'params_occur': {'self': [], 'c': [['n', 'c'],
@@ -41,7 +42,8 @@ class TestModuleRepresentations(unittest.TestCase):
                                         'params_descr': {'self': '', 'c': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}}]},
                             {'name': 'Bar', 'variables': {}, 'cls_var_occur': {},
-                             'funcs': [{'name': '__init__', 'q_name': 'Bar.__init__', 'params': {'self': ''}, 'ret_exprs': [],
+                             'funcs': [{'name': '__init__', 'q_name': 'Bar.__init__', 'fn_lc': ((27, 4), (28, 12)),
+                                        'params': {'self': ''}, 'ret_exprs': [],
                                         'params_occur': {'self': []}, 'ret_type': '', 'variables': {},
                                         'fn_var_occur': {}, 'params_descr': {'self': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}}]}]
@@ -49,12 +51,14 @@ class TestModuleRepresentations(unittest.TestCase):
         self.assertListEqual(cls_repr_mod_exp, processed_f.to_dict()['classes'])
 
     def test_mod_repr_fn_dict(self):
-        fn_repr_mod_exp = [{'name': 'my_fn', 'q_name': 'my_fn', 'params': {'x': 'builtins.int'}, 'ret_exprs': ['return x + 10'],
+        fn_repr_mod_exp = [{'name': 'my_fn', 'q_name': 'my_fn', 'fn_lc': ((31, 0), (32, 17)),
+                            'params': {'x': 'builtins.int'}, 'ret_exprs': ['return x + 10'],
                             'params_occur': {'x': []}, 'ret_type': 'builtins.int', 'variables': {}, 'fn_var_occur': {},
                             'params_descr': {'x': ''}, 'docstring': {'func': None, 'ret': None, 'long_descr': None}},
-                           {'name': 'foo', 'q_name': 'foo', 'params': {}, 'ret_exprs': [], 'params_occur': {}, 'ret_type': 'None',
-                            'variables': {}, 'fn_var_occur': {}, 'params_descr': {},
-                            'docstring': {'func': 'Foo docstring', 'ret': None, 'long_descr': None}}]
+                           {'name': 'foo', 'q_name': 'foo', 'fn_lc': ((35, 0), (39, 16)), 'params': {}, 'ret_exprs': [],
+                            'params_occur': {}, 'ret_type': 'None', 'variables': {}, 'fn_var_occur': {},
+                            'params_descr': {}, 'docstring': {'func': 'Foo docstring', 'ret': None,
+                                                              'long_descr': None}}]
 
         self.assertListEqual(fn_repr_mod_exp, processed_f.to_dict()['funcs'])
 
@@ -98,6 +102,10 @@ class TestClassRepresentation(unittest.TestCase):
     It tests the Dict-based representation of classes
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.maxDiff = None
+
     def test_cls_repr_dict_keys(self):
         cls_repr_dict_keys = ['name', 'variables', 'cls_var_occur', 'funcs']
         self.assertListEqual(cls_repr_dict_keys, list((processed_f.to_dict()['classes'][0].keys())))
@@ -107,13 +115,14 @@ class TestClassRepresentation(unittest.TestCase):
         self.assertEqual(cls_repr_name, processed_f.to_dict()['classes'][0]['name'])
 
     def test_cls_repr_fns_dict(self):
-        fns_repr_cls_exp = [{'name': '__init__', 'q_name': 'MyClass.__init__',
+        fns_repr_cls_exp = [{'name': '__init__', 'q_name': 'MyClass.__init__', 'fn_lc': ((18, 4), (19, 18)),
                              'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
                              'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                              'ret_type': 'None', 'variables': {'y': ''}, 'fn_var_occur': {'y': [['self', 'y', 'y']]},
                              'params_descr': {'self': '', 'y': ''},
                              'docstring': {'func': None, 'ret': None, 'long_descr': None}},
-                            {'name': 'cls_fn', 'q_name': 'MyClass.cls_fn', 'params': {'self': '', 'c': 'builtins.int'},
+                            {'name': 'cls_fn', 'q_name': 'MyClass.cls_fn', 'fn_lc': ((21, 4), (23, 44)),
+                             'params': {'self': '', 'c': 'builtins.int'},
                              'ret_exprs': ['return MyClass.cls_var + c / (2 + n)'],
                              'params_occur': {'self': [], 'c': [['n', 'c'], ['MyClass', 'cls_var', 'c', 'n']]},
                              'ret_type': 'builtins.float', 'variables': {'n': ''},
@@ -137,7 +146,7 @@ class TestFunctionRepresentation(unittest.TestCase):
     """
 
     def test_fn_repr_dict_keys(self):
-        fn_repr_dict_keys = ['name', 'q_name', 'params', 'ret_exprs', 'params_occur', 'ret_type', 'variables',
+        fn_repr_dict_keys = ['name', 'q_name', 'fn_lc', 'params', 'ret_exprs', 'params_occur', 'ret_type', 'variables',
                              'fn_var_occur', 'params_descr', 'docstring']
         fn_doc_repr_dict_keys = ['func', 'ret', 'long_descr']
         self.assertListEqual(fn_repr_dict_keys + fn_doc_repr_dict_keys,
@@ -145,8 +154,9 @@ class TestFunctionRepresentation(unittest.TestCase):
                              list(processed_f.to_dict()['classes'][0]['funcs'][0]['docstring'].keys()))
 
     def test_fn_repr_dict(self):
-        fn_repr_dict = {'name': '__init__', 'q_name': 'MyClass.__init__', 'params': {'self': '', 'y': 'builtins.float'},
-                        'ret_exprs': [], 'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
+        fn_repr_dict = {'name': '__init__', 'q_name': 'MyClass.__init__', 'fn_lc': ((18, 4), (19, 18)),
+                        'params': {'self': '', 'y': 'builtins.float'}, 'ret_exprs': [],
+                        'params_occur': {'self': [['self', 'y', 'y']], 'y': [['self', 'y', 'y']]},
                         'ret_type': 'None', 'variables': {'y': ''}, 'fn_var_occur': {'y': [['self', 'y', 'y']]},
                         'params_descr': {'self': '', 'y': ''},
                         'docstring': {'func': None, 'ret': None, 'long_descr': None}}


### PR DESCRIPTION
- Extracts line and column no. for the start and end of functions.
- Adds the JSON field `fn_lc` for functions. 
Ex. `fn_lc: ((1, 0), (5, 5))` The functions starts at line 1, col. 0 and ends at line 5, col. 5.