### PR TITLE
Extending TypeApplier to remove type annotations + Improvements

### DIFF
--- a/libsa4py/__main__.py
+++ b/libsa4py/__main__.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from multiprocessing import cpu_count
 from libsa4py.utils import find_repos_list
-from libsa4py.cst_pipeline import Pipeline, TypeAnnotatingProjects
+from libsa4py.cst_pipeline import Pipeline, TypeAnnotatingProjects, TypeAnnotationsRemoval
 from libsa4py.merge import merge_projects
 
 
@@ -14,6 +14,11 @@ def process_projects(args):
 def apply_types_projects(args):
     tap = TypeAnnotatingProjects(args.p, args.o)
     tap.run(args.j)
+
+
+def remove_err_type_annotations(args):
+    tar = TypeAnnotationsRemoval(args.p, args.o, "")
+    tar.run(args.j)
 
 
 def main():
@@ -52,6 +57,12 @@ def main():
     apply_parser.add_argument("--o", required=True, type=str, help="Path to store JSON-based processed projects")
     apply_parser.add_argument("--j", default=cpu_count(), type=int, help="Number of workers for processing projects")
     apply_parser.set_defaults(func=apply_types_projects)
+
+    remove_parser = sub_parsers.add_parser('remove')
+    remove_parser.add_argument("--p", required=True, type=str, help="Path to Python projects")
+    remove_parser.add_argument("--o", required=True, type=str, help="Path to store JSON-based processed projects")
+    remove_parser.add_argument("--j", default=cpu_count(), type=int, help="Number of workers for processing files")
+    remove_parser.set_defaults(func=remove_err_type_annotations)
 
     args = arg_parser.parse_args()
     args.func(args)

--- a/libsa4py/cst_pipeline.py
+++ b/libsa4py/cst_pipeline.py
@@ -311,16 +311,18 @@ class TypeAnnotationsRemoval:
         if init_tc == False and init_no_tc_err is None:
             return
         else:
-            tmp_f = create_tmp_file(".py")
-            f_tc_code, tc_errs, type_annot_r = self.__remove_unchecked_type_annot(f_read, f_d_repr, init_no_tc_err,
-                                                                                  tmp_f)
-            print(f"F: {f} | init_tc_errors: {init_no_tc_err} | tc_errors: {tc_errs} | ta_r: {type_annot_r} | \
-             total_ta: {f_d_repr['no_types_annot']['I'] + f_d_repr['no_types_annot']['D']}")
-            tc_res[f] = {"init_tc_errs": init_no_tc_err, "curr_tc_errs": tc_errs, "ta_rem": type_annot_r,
-                         "total_ta": f_d_repr["no_types_annot"]['I'] + f_d_repr["no_types_annot"]['D']}
-            # Path(join(self.output_path, Path(f).parent)).mkdir(parents=True, exist_ok=True)
-            # write_file(join(self.projects_path, f), f_tc_code)
-            delete_tmp_file(tmp_f)
+            # Only files with type annotations
+            if f_d_repr['no_types_annot']['I'] + f_d_repr['no_types_annot']['D'] > 0:
+                tmp_f = create_tmp_file(".py")
+                f_tc_code, tc_errs, type_annot_r = self.__remove_unchecked_type_annot(f_read, f_d_repr, init_no_tc_err,
+                                                                                      tmp_f)
+                print(f"F: {f} | init_tc_errors: {init_no_tc_err} | tc_errors: {tc_errs} | ta_r: {type_annot_r} | \
+                 total_ta: {f_d_repr['no_types_annot']['I'] + f_d_repr['no_types_annot']['D']}")
+                tc_res[f] = {"init_tc_errs": init_no_tc_err, "curr_tc_errs": tc_errs, "ta_rem": type_annot_r,
+                             "total_ta": f_d_repr["no_types_annot"]['I'] + f_d_repr["no_types_annot"]['D']}
+                # Path(join(self.output_path, Path(f).parent)).mkdir(parents=True, exist_ok=True)
+                # write_file(join(self.projects_path, f), f_tc_code)
+                delete_tmp_file(tmp_f)
 
     def run(self, jobs: int):
         merged_projects = load_json(join(self.processed_projects_path, "merged_512_projects.json"))
@@ -335,7 +337,7 @@ class TypeAnnotationsRemoval:
         ParallelExecutor(n_jobs=jobs)(total=len(not_tced_src_f))(delayed(self.process_file)(f, f_d, tc_res) \
                                                                  for f, f_d in not_tced_src_f)
 
-        save_json(join(self.processed_projects_path, "tc_ta_results.json"), tc_res)
+        save_json(join(self.processed_projects_path, "tc_ta_results.json"), tc_res.copy())
 
     def __remove_unchecked_type_annot(self, f_read: str, f_d_repr: dict, init_no_tc_err: int,
                                       f_out_temp: NamedTemporaryFile) -> Tuple[str, int, List[str]]:

--- a/libsa4py/cst_pipeline.py
+++ b/libsa4py/cst_pipeline.py
@@ -318,7 +318,7 @@ class TypeAnnotationsRemoval:
             delete_tmp_file(tmp_f)
 
     def run(self, jobs: int):
-        merged_projects = load_json(join(self.processed_projects_path, "merged_all_projects.json"))
+        merged_projects = load_json(join(self.processed_projects_path, "merged_512_projects.json"))
         not_tced_src_f: List[Tuple[str, dict]] = []
         for p, p_v in list(merged_projects['projects'].items()):
             for f, f_v in p_v['src_files'].items():
@@ -406,7 +406,7 @@ class TypeAnnotationsRemoval:
                 for p_n, p_t in fn["params"].items():
                     if p_t != "":
                         print(f"Type-checking function parameter {p_n} with annotation {p_t}")
-                        f_d_repr['classes'][c_i]['funcs'][fn_i]['params'][p_n] = p
+                        f_d_repr['classes'][c_i]['funcs'][fn_i]['params'][p_n] = ""
                         tc, no_tc_err, f_code = self.__type_check_type_annotation(f_read, f_d_repr, f_out_temp)
                         if tc:
                             return f_code, no_tc_err
@@ -420,7 +420,7 @@ class TypeAnnotationsRemoval:
                 for fn_v, fn_v_t in fn['variables'].items():
                     if fn_v_t != "":
                         print(f"Type-checking function variable {fn_v} with annotation {fn_v_t}")
-                        f_d_repr['classes'][c_i]['funcs'][fn_i]['variables'][fn_v] = p
+                        f_d_repr['classes'][c_i]['funcs'][fn_i]['variables'][fn_v] = ""
                         tc, no_tc_err, f_code = self.__type_check_type_annotation(f_read, f_d_repr, f_out_temp)
                         if tc:
                             return f_code, no_tc_err

--- a/libsa4py/cst_pipeline.py
+++ b/libsa4py/cst_pipeline.py
@@ -10,6 +10,7 @@ from tempfile import NamedTemporaryFile
 from pathlib import Path
 from datetime import timedelta
 from joblib import delayed
+from multiprocessing import Manager
 from dpu_utils.utils.dataloading import load_jsonl_gz
 from libsa4py.cst_extractor import Extractor
 from libsa4py.cst_transformers import TypeApplier
@@ -301,7 +302,7 @@ class TypeAnnotationsRemoval:
         self.output_path = output_path
         self.apply_nlp = apply_nlp
 
-    def process_file(self, f: str, f_d_repr: dict):
+    def process_file(self, f: str, f_d_repr: dict, tc_res: dict):
         f_read = read_file(join(self.projects_path, f))
         # TODO: The initial type-checking should not be done after adding no. type errors to the representation later on.
         init_tc, init_no_tc_err = type_check_single_file(join(self.projects_path, f),
@@ -313,7 +314,10 @@ class TypeAnnotationsRemoval:
             tmp_f = create_tmp_file(".py")
             f_tc_code, tc_errs, type_annot_r = self.__remove_unchecked_type_annot(f_read, f_d_repr, init_no_tc_err,
                                                                                   tmp_f)
-            print(f"F: {f} | init_tc_errors: {init_no_tc_err} | tc_errors: {tc_errs} | ta_r: {type_annot_r}")
+            print(f"F: {f} | init_tc_errors: {init_no_tc_err} | tc_errors: {tc_errs} | ta_r: {type_annot_r} | \
+             total_ta: {f_d_repr['no_types_annot']['I'] + f_d_repr['no_types_annot']['D']}")
+            tc_res[f] = {"init_tc_errs": init_no_tc_err, "curr_tc_errs": tc_errs, "ta_rem": type_annot_r,
+                         "total_ta": f_d_repr["no_types_annot"]['I'] + f_d_repr["no_types_annot"]['D']}
             # Path(join(self.output_path, Path(f).parent)).mkdir(parents=True, exist_ok=True)
             # write_file(join(self.projects_path, f), f_tc_code)
             delete_tmp_file(tmp_f)
@@ -326,8 +330,12 @@ class TypeAnnotationsRemoval:
                 if not f_v['tc']:
                     not_tced_src_f.append((f, f_v))
 
-        ParallelExecutor(n_jobs=jobs)(total=len(not_tced_src_f))(delayed(self.process_file)(f, f_d) \
+        manager = Manager()
+        tc_res = manager.dict()
+        ParallelExecutor(n_jobs=jobs)(total=len(not_tced_src_f))(delayed(self.process_file)(f, f_d, tc_res) \
                                                                  for f, f_d in not_tced_src_f)
+
+        save_json(join(self.processed_projects_path, "tc_ta_results.json"), tc_res)
 
     def __remove_unchecked_type_annot(self, f_read: str, f_d_repr: dict, init_no_tc_err: int,
                                       f_out_temp: NamedTemporaryFile) -> Tuple[str, int, List[str]]:

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -1011,6 +1011,7 @@ class TypeApplier(cst.CSTTransformer):
                                   updated_node: cst.SimpleStatementLine):
 
         # Untyped variables
+        t = None
         if match.matches(original_node, match.SimpleStatementLine(body=[match.Assign(targets=[match.AssignTarget(
                 target=match.DoNotCare())])])):
             if match.matches(original_node, match.SimpleStatementLine(body=[match.Assign(targets=[match.AssignTarget(
@@ -1050,10 +1051,18 @@ class TypeApplier(cst.CSTTransformer):
                         annotation=t_annot_node,
                         equal=original_node.body[0].equal)])
             else:
-                return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
-                                                                                            whitespace_before_equal=original_node.body[0].equal.whitespace_before,
-                                                                                            whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
-                                                                  value=original_node.body[0].value)])
+                try:
+                    return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
+                                                                                                whitespace_before_equal=original_node.body[0].equal.whitespace_before,
+                                                                                                whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
+                                                                    value=original_node.body[0].value)])
+                except AttributeError:
+                    print("AT", original_node.body[0])
+                    return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
+                                                                                                whitespace_before_equal=original_node.body[0].equal.whitespace_before,
+                                                                                                whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
+                                                                    value=original_node.body[0].value)])
+                    
 
         return original_node
 

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -1034,7 +1034,8 @@ class TypeApplier(cst.CSTTransformer):
                                             whitespace_before=original_node.body[0].targets[0].whitespace_before_equal))]
                     )
         # Typed variables
-        elif match.matches(original_node, match.SimpleStatementLine(body=[match.AnnAssign(target=match.DoNotCare())])):
+        elif match.matches(original_node, match.SimpleStatementLine(body=[match.AnnAssign(target=match.DoNotCare(),
+                                                                                          value=match.MatchIfTrue(lambda v: v is not None))])):
             if match.matches(original_node, match.SimpleStatementLine(body=[match.AnnAssign(target=match.Name(value=match.DoNotCare()))])):
                 t = self.__get_var_type_an_assign(original_node.body[0].target.value)
             elif match.matches(original_node, match.SimpleStatementLine(body=[match.AnnAssign(target=match.Attribute(value=match.Name(value=match.DoNotCare()),
@@ -1051,17 +1052,10 @@ class TypeApplier(cst.CSTTransformer):
                         annotation=t_annot_node,
                         equal=original_node.body[0].equal)])
             else:
-                try:
-                    return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
-                                                                                                whitespace_before_equal=original_node.body[0].equal.whitespace_before,
-                                                                                                whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
-                                                                    value=original_node.body[0].value)])
-                except AttributeError:
-                    print("AT", original_node.body[0])
-                    return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
-                                                                                                whitespace_before_equal=original_node.body[0].equal.whitespace_before,
-                                                                                                whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
-                                                                    value=original_node.body[0].value)])
+                return updated_node.with_changes(body=[cst.Assign(targets=[cst.AssignTarget(target=original_node.body[0].target,
+                                                                                            whitespace_before_equal=original_node.body[0].equal.whitespace_before,
+                                                                                            whitespace_after_equal=original_node.body[0].equal.whitespace_after)],
+                                                                value=original_node.body[0].value)])
                     
 
         return original_node

--- a/libsa4py/type_check.py
+++ b/libsa4py/type_check.py
@@ -7,6 +7,7 @@ MIT License
 
 from abc import ABC, abstractmethod
 from os.path import dirname, basename
+from typing import Tuple, Union
 from collections import Counter, namedtuple
 import toml
 import os
@@ -164,9 +165,9 @@ class MypyManager(TCManager):
             print(f"Error breaking down: {parsed_result.err_breakdown}.")
 
 
-def type_check_single_file(f_path: str, tc: TCManager) -> bool:
+def type_check_single_file(f_path: str, tc: TCManager) -> Tuple[bool, Union[int, None]]:
     no_t_err = tc.heavy_assess(f_path)
     if no_t_err is not None:
-        return True if no_t_err.no_type_errs == 0 else False
+        return (True, 0) if no_t_err.no_type_errs == 0 else (False, no_t_err.no_type_errs)
     else:
-        return False
+        return False, None

--- a/libsa4py/type_check.py
+++ b/libsa4py/type_check.py
@@ -166,8 +166,12 @@ class MypyManager(TCManager):
 
 
 def type_check_single_file(f_path: str, tc: TCManager) -> Tuple[bool, Union[int, None]]:
-    no_t_err = tc.heavy_assess(f_path)
-    if no_t_err is not None:
-        return (True, 0) if no_t_err.no_type_errs == 0 else (False, no_t_err.no_type_errs)
-    else:
+    try:
+        no_t_err = tc.heavy_assess(f_path)
+        if no_t_err is not None:
+            return (True, 0) if no_t_err.no_type_errs == 0 else (False, no_t_err.no_type_errs)
+        else:
+            return False, None
+    except IndexError:
+        print(f"f: {f_path} - No output from Mypy!")
         return False, None

--- a/libsa4py/utils.py
+++ b/libsa4py/utils.py
@@ -2,6 +2,7 @@ from typing import List
 from tqdm import tqdm
 from joblib import Parallel
 from os.path import join, isdir
+from tempfile import NamedTemporaryFile
 from pathlib import Path
 import time
 import os
@@ -113,3 +114,24 @@ def find_repos_list(projects_path: str) -> List[dict]:
 def mk_dir_not_exist(path: str):
     if not isdir(path):
         os.mkdir(path)
+
+
+def create_tmp_file(suffix: str):
+    """
+    It creates a temporary file.
+    NOTE: the temp file should be deleted manually after creation.
+    """
+    return NamedTemporaryFile(mode="w", delete=False, suffix=suffix)
+
+
+def delete_tmp_file(tmp_f: NamedTemporaryFile):
+    try:
+        os.unlink(tmp_f.name)
+    except TypeError:
+        print("Couldn't delete ", tmp_f.name)
+
+
+def write_to_tmp_file(tmp_f: NamedTemporaryFile, text: str):
+    tmp_f.write(text)
+    #tmp_f.close()
+    return tmp_f

--- a/tests/examples/type_apply_ex.json
+++ b/tests/examples/type_apply_ex.json
@@ -64,7 +64,7 @@
             "name": "Foo",
             "q_name": "Foo",
             "variables": {
-                "foo_v": "",
+                "foo_v": "str",
                 "foo_p": "pathlib.Path"
             },
             "cls_var_occur": {
@@ -134,11 +134,11 @@
                             16
                         ]
                     ],
-                    "params": {},
+                    "params": {"self":  ""},
                     "ret_exprs": [],
                     "params_occur": {},
                     "ret_type": "",
-                    "variables": {},
+                    "variables": {"i":  "int"},
                     "fn_var_occur": {},
                     "params_descr": {},
                     "docstring": {

--- a/tests/examples/type_apply_typed_ex.json
+++ b/tests/examples/type_apply_typed_ex.json
@@ -8,7 +8,8 @@
     "variables": {
         "a": "",
         "l": "",
-        "c": ""
+        "c": "",
+        "h": ""
     },
     "mod_var_occur": {
         "a": [

--- a/tests/examples/type_apply_typed_ex.json
+++ b/tests/examples/type_apply_typed_ex.json
@@ -1,0 +1,223 @@
+{
+  "tests/examples": {
+    "src_files": {
+      "type_apply_typed.py": {
+    "untyped_seq": "a = [number] [EOL] l = [ [number] , [number] , [number] ] [EOL] c = [number] [EOL] [EOL] def foo ( x , y ) : [EOL] z = x + y [EOL] return z [EOL] [EOL] class Bar : [EOL] bar_var1 = [string] [EOL] bar_var2 = [number] [EOL] def __init__ ( a , b ) : [EOL] self . a = a [EOL] self . b = b [EOL] def delta ( n ) : [EOL] return [ [number] ] * p [EOL]",
+    "typed_seq": "$builtins.int$ 0 0 0 $List[int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 $builtins.float$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 $List[float]$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0",
+    "imports": [],
+    "variables": {
+        "a": "",
+        "l": "",
+        "c": ""
+    },
+    "mod_var_occur": {
+        "a": [
+            [
+                "self",
+                "a",
+                "builtins",
+                "int",
+                "a"
+            ]
+        ],
+        "l": [],
+        "c": []
+    },
+    "classes": [
+        {
+            "name": "Bar",
+            "q_name": "Bar",
+            "variables": {
+                "bar_var1": "",
+                "bar_var2": ""
+            },
+            "cls_var_occur": {
+                "bar_var1": [],
+                "bar_var2": []
+            },
+            "funcs": [
+                {
+                    "name": "__init__",
+                    "q_name": "Bar.__init__",
+                    "fn_lc": [
+                        [
+                            12,
+                            4
+                        ],
+                        [
+                            14,
+                            18
+                        ]
+                    ],
+                    "params": {
+                        "a": "",
+                        "b": ""
+                    },
+                    "ret_exprs": [],
+                    "params_occur": {
+                        "a": [
+                            [
+                                "self",
+                                "a",
+                                "builtins",
+                                "int",
+                                "a"
+                            ]
+                        ],
+                        "b": [
+                            [
+                                "self",
+                                "b",
+                                "b"
+                            ]
+                        ]
+                    },
+                    "ret_type": "",
+                    "variables": {
+                        "a": "",
+                        "b": ""
+                    },
+                    "fn_var_occur": {
+                        "a": [
+                            [
+                                "self",
+                                "a",
+                                "builtins",
+                                "int",
+                                "a"
+                            ]
+                        ],
+                        "b": [
+                            [
+                                "self",
+                                "b",
+                                "b"
+                            ]
+                        ]
+                    },
+                    "params_descr": {
+                        "a": "",
+                        "b": ""
+                    },
+                    "docstring": {
+                        "func": null,
+                        "ret": null,
+                        "long_descr": null
+                    }
+                },
+                {
+                    "name": "delta",
+                    "q_name": "Bar.delta",
+                    "fn_lc": [
+                        [
+                            15,
+                            4
+                        ],
+                        [
+                            16,
+                            25
+                        ]
+                    ],
+                    "params": {
+                        "n": ""
+                    },
+                    "ret_exprs": [
+                        "return [2.17] * p"
+                    ],
+                    "params_occur": {
+                        "n": []
+                    },
+                    "ret_type": "",
+                    "variables": {},
+                    "fn_var_occur": {},
+                    "params_descr": {
+                        "n": ""
+                    },
+                    "docstring": {
+                        "func": null,
+                        "ret": null,
+                        "long_descr": null
+                    }
+                }
+            ]
+        }
+    ],
+    "funcs": [
+        {
+            "name": "foo",
+            "q_name": "foo",
+            "fn_lc": [
+                [
+                    5,
+                    0
+                ],
+                [
+                    7,
+                    12
+                ]
+            ],
+            "params": {
+                "x": "",
+                "y": ""
+            },
+            "ret_exprs": [
+                "return z"
+            ],
+            "params_occur": {
+                "x": [
+                    [
+                        "z",
+                        "builtins",
+                        "int",
+                        "x",
+                        "y"
+                    ]
+                ],
+                "y": [
+                    [
+                        "z",
+                        "builtins",
+                        "int",
+                        "x",
+                        "y"
+                    ]
+                ]
+            },
+            "ret_type": "",
+            "variables": {
+                "z": ""
+            },
+            "fn_var_occur": {
+                "z": [
+                    [
+                        "z",
+                        "builtins",
+                        "int",
+                        "x",
+                        "y"
+                    ]
+                ]
+            },
+            "params_descr": {
+                "x": "",
+                "y": ""
+            },
+            "docstring": {
+                "func": null,
+                "ret": null,
+                "long_descr": null
+            }
+        }
+    ],
+    "set": null,
+    "tc": false,
+    "no_types_annot": {
+        "U": 0,
+        "D": 0,
+        "I": 0
+    },
+    "type_annot_cove": 0.0
+}
+    }
+  }
+}

--- a/tests/test_type_apply.py
+++ b/tests/test_type_apply.py
@@ -84,6 +84,7 @@ def Bar(x: typing.List[builtins.str]=['apple', 'orange'], *, c)-> typing.List[bu
 test_file_typed = """a: int = 12
 l: List[int] = [1,2,3]
 c = 2.71
+h: dict
 def foo(x: int, y: int) -> int:
     z: int = x + y
     return z
@@ -100,6 +101,7 @@ class Bar:
 test_file_typed_exp = """a = 12
 l = [1,2,3]
 c = 2.71
+h: dict
 def foo(x, y):
     z = x + y
     return z


### PR DESCRIPTION
- Improvements to `TypeApplier` like adding types to class attributes.
- Removing type annotations if not present in the JSON output.
- A parallel pipeline to remove type annotations that do not type-check by `mypy`.