### PR TITLE
Improve extraction of names from import statements

### DIFF
--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -209,8 +209,15 @@ class Visitor(cst.CSTVisitor):
             import_name = self.__clean_string_whitespace(import_name)
             self.imports.append(import_name)
 
+        if "alias" in import_info:
+            import_name = self.__clean_string_whitespace(import_info["alias"])
+            self.imports.append(import_name)
+
         # No need to traverse children, as we already performed the matching.
         return False
+
+    def visit_ImportFrom(self, node: cst.ImportFrom):
+        self.imports.extend([n.value for n in match.findall(node.module, match.Name(value=match.DoNotCare()))])
 
     def visit_Assign(self, node: cst.Assign):
         """

--- a/tests/exp_outputs/extractor_out.json
+++ b/tests/exp_outputs/extractor_out.json
@@ -2,6 +2,7 @@
     "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
     "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
     "imports": [
+        "os",
         "path",
         "math"
     ],

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -220,17 +220,29 @@
                 "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] from . . test_imports import TestImports [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] relative_i = TestImports ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 $test_imports.TestImports$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "Dict",
+                    "_Dict",
+                    "typing",
                     "Tuple",
                     "Union",
+                    "libsa4py",
+                    "cst_transformers",
                     "TypeQualifierResolver",
+                    "representations",
                     "Bar",
+                    "test_imports",
                     "TestImports",
                     "typing",
+                    "t",
                     "typing",
+                    "collections",
+                    "abc",
                     "Sequence",
+                    "builtins",
                     "str",
                     "numpy",
+                    "np",
                     "builtins"
                 ],
                 "variables": {
@@ -991,6 +1003,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from . different_fns import add [EOL] [EOL] [EOL] PI = [number] [EOL] MOD_CONSTANT = [number] [EOL] [EOL] [EOL] class TestVarArgOccur : [EOL] [EOL] greeting = [string] [EOL] num = [number] [EOL] cls_constant = MOD_CONSTANT + [number] [EOL] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] self . y = y [EOL] [EOL] def fn_params_occur ( self , param1 , param2 ) : [EOL] z = param1 + param2 [EOL] [EOL] add_x_y = add ( param1 , param2 ) [EOL] [EOL] list_comp = [ i for i in range ( param1 ** param2 * z ) ] [EOL] [EOL] if param1 * add_x_y == [number] : [EOL] pass [EOL] elif param1 % param2 < [number] : [EOL] pass [EOL] [EOL] while param2 * param1 * z // [number] : [EOL] pass [EOL] [EOL] for i in range ( param1 + z * [number] ) : [EOL] pass [EOL] [EOL] with z * param2 as f : [EOL] print ( z ** param2 / f ) [EOL] [EOL] assert param1 == add_x_y * z [EOL] yield z + param2 [EOL] return param1 + [number] + param2 / [number] [EOL] [EOL] def local_vars_usage ( self , p ) : [EOL] v = sum ( [ [number] , [number] , [number] , [number] ] ) [EOL] v_1 = v + p + [number] [EOL] [EOL] for i in range ( [number] , v + v_1 ) : [EOL] i += v + [number] [EOL] yield i + v_1 [EOL] [EOL] if v < [number] and v_1 + v > [number] : [EOL] print ( v ) [EOL] [EOL] elif v * v_1 != [number] : [EOL] print ( v * v_1 ) [EOL] else : [EOL] print ( v_1 ) [EOL] [EOL] while v + v_1 < p : [EOL] v *= [number] + v_1 [EOL] [EOL] with ( v_1 + p // [number] ) as n : [EOL] assert v != n [EOL] [EOL] return v + p + p + [number] [EOL] [EOL] [comment] [EOL] def class_vars_usage ( self ) : [EOL] c = self . x + TestVarArgOccur . num [EOL] [EOL] if TestVarArgOccur . num + c < [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , TestVarArgOccur . num ) : [EOL] yield TestVarArgOccur . num + i [EOL] [EOL] while TestVarArgOccur . num < [number] : [EOL] TestVarArgOccur . num -= [number] [EOL] [EOL] with ( TestVarArgOccur . greeting + [string] ) as f : [EOL] pass [EOL] [EOL] assert c != TestVarArgOccur . cls_constant [EOL] [EOL] return TestVarArgOccur . cls_constant + c [EOL] [EOL] [comment] [EOL] def module_vars_usage ( self , add_something ) : [EOL] if PI + add_something > [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , int ( PI ) ) : [EOL] pass [EOL] [EOL] while PI + MOD_CONSTANT > [number] : [EOL] PI = - [number] + add_something [EOL] [EOL] with ( MOD_CONSTANT + PI + add_something ) as n : [EOL] print ( n ) [EOL] [EOL] def formatted_str ( self , p ) : [EOL] x = [number] [EOL] y = [number] [EOL] print ( f\" [string] { x * y // p } [string] \" ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 $builtins.int$ 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "different_fns",
                     "add"
                 ],
                 "variables": {
@@ -2014,8 +2027,12 @@
                 "imports": [
                     "math",
                     "typing",
+                    "t",
+                    "os",
+                    "path",
                     "join",
                     "split",
+                    "string",
                     "collections"
                 ],
                 "variables": {},
@@ -2275,6 +2292,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import List [EOL] [EOL] [comment] [EOL] PI = [number] [EOL] CONSTANT = [number] [EOL] M_FOO , M_BAR = [number] , [number] [EOL] [EOL] LONG_STRING = [string] [EOL] [EOL] [EOL] class Test : [EOL] [comment] [EOL] x = [number] [EOL] u , f = [number] , [string] [EOL] out_y = [string] [EOL] scientific_num = [number] [EOL] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . y = [string] [EOL] self . b , self . c = [number] , [string] [EOL] self . error = ... [EOL] [EOL] def local_var_assings ( self ) : [EOL] f_no = [number] [EOL] l = [ [string] , [string] ] [EOL] foo = ... [EOL] [EOL] def tuple_assigns ( self ) : [EOL] x , y , z = [number] , [number] , [number] [EOL] a , ( b , c ) = [number] , ( [number] , [number] ) [EOL] d , ( ( e , f ) , ( g , h ) ) = [number] , ( ( [number] , [number] ) , ( [number] , [number] ) ) [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [comment]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "List"
                 ],
                 "variables": {
@@ -3251,8 +3269,10 @@
                 "untyped_seq": "[docstring] [EOL] from typing import List [EOL] import math as m [EOL] [EOL] CONSTANT = [number] [EOL] STRING = [string] [EOL] [EOL] [string] [string] == STRING [EOL] [EOL] d = { k : v for k , v in [ ( [number] , [number] ) , ( [number] , [number] ) ] } [EOL] d_e = { ** d , ** d } [EOL] [EOL] f_str = f\" [string] { STRING + STRING }\" [EOL] [EOL] l = [ [number] , [number] , [number] , [number] ] [EOL] [EOL] print ( l [ [number] ] ) [EOL] [EOL] class Delta : [EOL] def __init__ ( self ) : [EOL] self . x = [string] [EOL] [EOL] def foo ( x , y , * s ) : [EOL] global CONSTANT [EOL] n = [number] [EOL] n //= n % x [EOL] y %= x ; x **= n [EOL] if x | x & y | ~ y | x ^ y : [EOL] x << y [EOL] y >> x [EOL] s <<= x [EOL] x >>= y [EOL] y &= x [EOL] x |= y [EOL] x ^= y [EOL] if x <= y or y >= x and ~ x : [EOL] pass [EOL] [EOL] assert x != y [EOL] [EOL] return n + x // y [EOL] [EOL] @ set def bar ( x ) : [EOL] v = foo ( x , [number] ) [EOL] try : [EOL] v /= x [EOL] except ZeroDivisionError : [EOL] raise RuntimeError [EOL] finally : [EOL] pass [EOL] if x < v and v > x : [EOL] x *= x [EOL] else : [EOL] pass [EOL] del x [EOL] return v [EOL] [EOL] for i in range ( CONSTANT + [number] + bar ( [number] ) ) : [EOL] if i + foo ( i , [number] ) + [number] : [EOL] print ( i / i ) [EOL] i += [number] - [number] ** [number] [EOL] i -= [number] [EOL] while i < [number] : [EOL] i = i + [number] [EOL] [EOL] with ( i + [number] ) as w : [EOL] pass [EOL] [EOL] foo ( [number] , [number] , * l )",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0",
                 "imports": [
+                    "typing",
                     "List",
-                    "math"
+                    "math",
+                    "m"
                 ],
                 "variables": {
                     "constant": "builtins.int",
@@ -3662,6 +3682,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL] [EOL] [EOL] [comment] [EOL] def fn_lineno ( x ) : [EOL] print ( x )",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "Optional"
                 ],
                 "variables": {},
@@ -4264,6 +4285,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "os",
                     "path",
                     "math"
                 ],

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -220,17 +220,29 @@
                 "untyped_seq": "from typing import Dict as _Dict [EOL] from typing import Tuple , Union [EOL] from libsa4py . cst_transformers import TypeQualifierResolver [EOL] from . representations import Bar [EOL] from . . test_imports import TestImports [EOL] import typing as t [EOL] import typing [EOL] from collections . abc import Sequence [EOL] from builtins import str [EOL] import numpy as np [EOL] import builtins [EOL] [EOL] d = { } [EOL] l = [ ] [EOL] q_v = [ [number] ] [EOL] l_n = ... [EOL] t_e = ( ) [EOL] u_d = None [EOL] c = None [EOL] c_h = None [EOL] t_a = t . List [EOL] tqr = TypeQualifierResolver ( ) [EOL] lt = [string] [EOL] s = [ [number] , [number] ] [EOL] N = [ ] [EOL] rl = Bar ( ) [EOL] b = True [EOL] relative_i = TestImports ( ) [EOL] [EOL] class Foo : [EOL] foo_seq = [ ] [EOL] def __init__ ( self , x , y = None ) : [EOL] class Delta : [EOL] pass [EOL] self . x = x [EOL] n = np . int ( [number] ) [EOL] d = Delta ( ) [EOL] [EOL] def bar ( self ) : [EOL] return np . array ( [ [number] , [number] , [number] ] ) [EOL] [EOL] def shadow_qn ( self ) : [EOL] sq = [string] [EOL] [EOL] for str in sq : [EOL] print ( str ) [EOL] [EOL] u = Foo ( t_e ) [EOL] foo = Foo ( t_e ) [EOL] foo_t = ( Foo ( t_e ) , TypeQualifierResolver ( ) ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Dict$ 0 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 $typing.List[typing.Tuple[builtins.int,builtins.int]]$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 $typing.Union[typing.List[typing.Tuple[builtins.str,builtins.int]],typing.Tuple[typing.Any],typing.Tuple[typing.List[typing.Tuple[typing.Set[builtins.int]]]]]$ 0 0 0 $typing.Callable[...,typing.List]$ 0 0 0 $typing.Callable[[typing.List,typing.Dict],builtins.int]$ 0 0 0 $typing.Type[typing.List]$ 0 0 0 0 0 $libsa4py.cst_transformers.TypeQualifierResolver$ 0 0 0 0 0 $typing.Literal[\"123\"]$ 0 0 0 $[]$ 0 0 0 0 0 0 0 $typing.Union[typing.List,None]$ 0 0 0 0 $representations.Bar$ 0 0 0 0 0 $True$ 0 0 0 $test_imports.TestImports$ 0 0 0 0 0 0 0 0 0 0 $collections.abc.Sequence$ 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Pattern$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Tuple$ 0 $typing.Tuple$ 0 $numpy.int$ 0 0 0 0 0 0 0 0 $Delta$ 0 0 0 0 0 0 0 $numpy.array$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 $\"Foo\"$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $Foo$ 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 $typing.Tuple[Foo,libsa4py.cst_transformers.TypeQualifierResolver]$ 0 0 0 0 $typing.Tuple[typing.Any,...]$ 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "Dict",
+                    "_Dict",
+                    "typing",
                     "Tuple",
                     "Union",
+                    "libsa4py",
+                    "cst_transformers",
                     "TypeQualifierResolver",
+                    "representations",
                     "Bar",
+                    "test_imports",
                     "TestImports",
                     "typing",
+                    "t",
                     "typing",
+                    "collections",
+                    "abc",
                     "Sequence",
+                    "builtins",
                     "str",
                     "numpy",
+                    "np",
                     "builtins"
                 ],
                 "variables": {
@@ -1037,6 +1049,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from . different_fns import add [EOL] [EOL] [EOL] PI = [number] [EOL] MOD_CONSTANT = [number] [EOL] [EOL] [EOL] class TestVarArgOccur : [EOL] [EOL] greeting = [string] [EOL] num = [number] [EOL] cls_constant = MOD_CONSTANT + [number] [EOL] [EOL] def __init__ ( self , x , y ) : [EOL] self . x = x [EOL] self . y = y [EOL] [EOL] def fn_params_occur ( self , param1 , param2 ) : [EOL] z = param1 + param2 [EOL] [EOL] add_x_y = add ( param1 , param2 ) [EOL] [EOL] list_comp = [ i for i in range ( param1 ** param2 * z ) ] [EOL] [EOL] if param1 * add_x_y == [number] : [EOL] pass [EOL] elif param1 % param2 < [number] : [EOL] pass [EOL] [EOL] while param2 * param1 * z // [number] : [EOL] pass [EOL] [EOL] for i in range ( param1 + z * [number] ) : [EOL] pass [EOL] [EOL] with z * param2 as f : [EOL] print ( z ** param2 / f ) [EOL] [EOL] assert param1 == add_x_y * z [EOL] yield z + param2 [EOL] return param1 + [number] + param2 / [number] [EOL] [EOL] def local_vars_usage ( self , p ) : [EOL] v = sum ( [ [number] , [number] , [number] , [number] ] ) [EOL] v_1 = v + p + [number] [EOL] [EOL] for i in range ( [number] , v + v_1 ) : [EOL] i += v + [number] [EOL] yield i + v_1 [EOL] [EOL] if v < [number] and v_1 + v > [number] : [EOL] print ( v ) [EOL] [EOL] elif v * v_1 != [number] : [EOL] print ( v * v_1 ) [EOL] else : [EOL] print ( v_1 ) [EOL] [EOL] while v + v_1 < p : [EOL] v *= [number] + v_1 [EOL] [EOL] with ( v_1 + p // [number] ) as n : [EOL] assert v != n [EOL] [EOL] return v + p + p + [number] [EOL] [EOL] [comment] [EOL] def class_vars_usage ( self ) : [EOL] c = self . x + TestVarArgOccur . num [EOL] [EOL] if TestVarArgOccur . num + c < [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , TestVarArgOccur . num ) : [EOL] yield TestVarArgOccur . num + i [EOL] [EOL] while TestVarArgOccur . num < [number] : [EOL] TestVarArgOccur . num -= [number] [EOL] [EOL] with ( TestVarArgOccur . greeting + [string] ) as f : [EOL] pass [EOL] [EOL] assert c != TestVarArgOccur . cls_constant [EOL] [EOL] return TestVarArgOccur . cls_constant + c [EOL] [EOL] [comment] [EOL] def module_vars_usage ( self , add_something ) : [EOL] if PI + add_something > [number] : [EOL] pass [EOL] [EOL] for i in range ( [number] , int ( PI ) ) : [EOL] pass [EOL] [EOL] while PI + MOD_CONSTANT > [number] : [EOL] PI = - [number] + add_something [EOL] [EOL] with ( MOD_CONSTANT + PI + add_something ) as n : [EOL] print ( n ) [EOL] [EOL] def formatted_str ( self , p ) : [EOL] x = [number] [EOL] y = [number] [EOL] print ( f\" [string] { x * y // p } [string] \" ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 $builtins.int$ 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "different_fns",
                     "add"
                 ],
                 "variables": {
@@ -2271,8 +2284,12 @@
                 "imports": [
                     "math",
                     "typing",
+                    "t",
+                    "os",
+                    "path",
                     "join",
                     "split",
+                    "string",
                     "collections"
                 ],
                 "variables": {},
@@ -2546,6 +2563,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import List [EOL] [EOL] [comment] [EOL] PI = [number] [EOL] CONSTANT = [number] [EOL] M_FOO , M_BAR = [number] , [number] [EOL] [EOL] LONG_STRING = [string] [EOL] [EOL] [EOL] class Test : [EOL] [comment] [EOL] x = [number] [EOL] u , f = [number] , [string] [EOL] out_y = [string] [EOL] scientific_num = [number] [EOL] [EOL] def __init__ ( self , x ) : [EOL] self . x = x [EOL] self . y = [string] [EOL] self . b , self . c = [number] , [string] [EOL] self . error = ... [EOL] [EOL] def local_var_assings ( self ) : [EOL] f_no = [number] [EOL] l = [ [string] , [string] ] [EOL] foo = ... [EOL] [EOL] def tuple_assigns ( self ) : [EOL] x , y , z = [number] , [number] , [number] [EOL] a , ( b , c ) = [number] , ( [number] , [number] ) [EOL] d , ( ( e , f ) , ( g , h ) ) = [number] , ( ( [number] , [number] ) , ( [number] , [number] ) ) [EOL] [EOL] [comment] [EOL] [comment] [EOL] [comment] [EOL] [comment]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List$ 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $typing.List[builtins.str]$ 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "List"
                 ],
                 "variables": {
@@ -3596,8 +3614,10 @@
                 "untyped_seq": "[docstring] [EOL] from typing import List [EOL] import math as m [EOL] [EOL] CONSTANT = [number] [EOL] STRING = [string] [EOL] [EOL] [string] [string] == STRING [EOL] [EOL] d = { k : v for k , v in [ ( [number] , [number] ) , ( [number] , [number] ) ] } [EOL] d_e = { ** d , ** d } [EOL] [EOL] f_str = f\" [string] { STRING + STRING }\" [EOL] [EOL] l = [ [number] , [number] , [number] , [number] ] [EOL] [EOL] print ( l [ [number] ] ) [EOL] [EOL] class Delta : [EOL] def __init__ ( self ) : [EOL] self . x = [string] [EOL] [EOL] def foo ( x , y , * s ) : [EOL] global CONSTANT [EOL] n = [number] [EOL] n //= n % x [EOL] y %= x ; x **= n [EOL] if x | x & y | ~ y | x ^ y : [EOL] x << y [EOL] y >> x [EOL] s <<= x [EOL] x >>= y [EOL] y &= x [EOL] x |= y [EOL] x ^= y [EOL] if x <= y or y >= x and ~ x : [EOL] pass [EOL] [EOL] assert x != y [EOL] [EOL] return n + x // y [EOL] [EOL] @ set def bar ( x ) : [EOL] v = foo ( x , [number] ) [EOL] try : [EOL] v /= x [EOL] except ZeroDivisionError : [EOL] raise RuntimeError [EOL] finally : [EOL] pass [EOL] if x < v and v > x : [EOL] x *= x [EOL] else : [EOL] pass [EOL] del x [EOL] return v [EOL] [EOL] for i in range ( CONSTANT + [number] + bar ( [number] ) ) : [EOL] if i + foo ( i , [number] ) + [number] : [EOL] print ( i / i ) [EOL] i += [number] - [number] ** [number] [EOL] i -= [number] [EOL] while i < [number] : [EOL] i = i + [number] [EOL] [EOL] with ( i + [number] ) as w : [EOL] pass [EOL] [EOL] foo ( [number] , [number] , * l )",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.List[builtins.int]$ 0",
                 "imports": [
+                    "typing",
                     "List",
-                    "math"
+                    "math",
+                    "m"
                 ],
                 "variables": {
                     "CONSTANT": "builtins.int",
@@ -4097,6 +4117,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from typing import Optional [EOL] [EOL] [EOL] [comment] [EOL] def add ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def noargs ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def no_params ( ) : [EOL] return [number] [EOL] [EOL] [EOL] [comment] [EOL] def noreturn ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_none ( x ) : [EOL] print ( x ) [EOL] [EOL] [EOL] [comment] [EOL] def return_optional ( y ) : [EOL] if len ( y ) == [number] : [EOL] return None [EOL] return y [EOL] [EOL] [EOL] [comment] [EOL] def untyped_args ( x , y ) : [EOL] return x + y [EOL] [EOL] [EOL] [comment] [EOL] def with_inner ( ) : [EOL] def inner ( x ) : [EOL] [docstring] [EOL] return [number] + x [EOL] return inner ( [number] ) [EOL] [EOL] [EOL] [comment] [EOL] def varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def untyped_varargs ( * xs ) : [EOL] sum = [number] [EOL] for x in xs : [EOL] sum += x [EOL] return sum [EOL] [EOL] [EOL] [comment] [EOL] def kwarg_method ( a , * b , ** c ) : [EOL] return c [EOL] [EOL] [EOL] [comment] [EOL] async def async_fn ( y ) : [EOL] return await y [EOL] [EOL] [EOL] [comment] [EOL] def abstract_fn ( name ) : ... [EOL] [EOL] [EOL] [comment] [EOL] def fn_lineno ( x ) : [EOL] print ( x )",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $typing.Optional[builtins.int]$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.str$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "typing",
                     "Optional"
                 ],
                 "variables": {},
@@ -4723,6 +4744,7 @@
                 "untyped_seq": "[docstring] [EOL] [EOL] from os import path [EOL] import math [EOL] [EOL] [comment] [EOL] CONSTANT = [string] [EOL] [EOL] [EOL] class MyClass : [EOL] [docstring] [EOL] cls_var = [number] [comment] [EOL] [EOL] def __init__ ( self , y ) : [EOL] self . y = y [EOL] [EOL] def cls_fn ( self , c ) : [EOL] n = c + [number] [EOL] return MyClass . cls_var + c / ( [number] + n ) [EOL] [EOL] [EOL] class Bar : [EOL] def __init__ ( self ) : [EOL] pass [EOL] [EOL] [EOL] def my_fn ( x ) : [EOL] return x + [number] [EOL] [EOL] [EOL] def foo ( ) : [EOL] [docstring] [EOL] print ( [string] ) [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.int$ 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 0 0 0 0 $None$ 0 0 0 0 0 0 0 0 0 0 0",
                 "imports": [
+                    "os",
                     "path",
                     "math"
                 ],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -23,9 +23,18 @@ class TestImports(unittest.TestCase):
         imp_alias_exp = 'typing'
         self.assertEqual(imp_alias_exp in self.processed_f['imports'], True)
 
+    def test_import_asname(self):
+        imp_asname_exp ="t"
+        self.assertEqual(imp_asname_exp in self.processed_f['imports'], True)
+
     def test_inner_imports(self):
         imp_inner_imports = 'collections'
         self.assertEqual(imp_inner_imports in self.processed_f['imports'], True)
 
     def test_star_import(self):
-        pass  # TODO: extracting star imports?
+        imp_star_exp = 'string'
+        self.assertEqual(imp_star_exp in self.processed_f['imports'], True)
+
+    def test_module_from_import(self):
+        imp_module = ['os', 'path']
+        self.assertEqual(all(i for i in imp_module if i in self.processed_f['imports']), True)


### PR DESCRIPTION
- Adds alias names to the import names in JSON output. e.g. `import math as m`, `m` will be added the import names.
- Adds module names from imports to JSON Output. e.g. 'from os.path import join', `os` and `path` will be added to the import names.