### PR TITLE
Adding line and column no. info for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to the [LibSA4Py](https://github.com/saltudelft/libsa4py) to
 - Supporting qualified names for classes by adding the `q_name` field to the JSON output.
 - Adding line and column no. info for the start and end of:
   - Functions definitions
+  - Class definitions
   - Module-level variables
   - Class variables
   - Functions' local variables
-- Improved the performance of the NLP preprocessing quite significantly (~10x). 
+- Improved the performance of the NLP preprocessing quite significantly (~10x).
 
 ### Fixed
 - When applying types to functions' parameters, parameters with the default value of lambdas causes an exception for matching functions' signature.

--- a/JSONOutput.md
+++ b/JSONOutput.md
@@ -54,6 +54,7 @@ The following JSON object represents a processed class:
 {
   "name": "",
   "q_name": "",
+  "cls_lc": [[5,0], [10, 7]],
   "variables": {"var_name": "type"},
   "cls_var_occur": {"var_name": []},
   "cls_var_ln": {"var_name": [[1,0], [2, 2]]},
@@ -64,6 +65,7 @@ The following JSON object represents a processed class:
 Description of the fields:
 - `name`: The name of the processed class.
 - `q_name`: The qualified name of the processed class.
+- `cls_lc`: Contains line and column no. info for the start and end of the class.
 - `variables`: Contains class variables' names and their type.
 - `cls_var_occur`: Contains class variables' usage inside the class.
 - `cls_var_ln`: Contains line and column no. info for the start and end of class variables.

--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -63,6 +63,7 @@ class Visitor(cst.CSTVisitor):
         cls = self.cls_stack.pop()
         cls.variables_use_occur = self.__find_args_vars_use(list(cls.variables.keys()), self.cls_may_vars_use)
         cls.q_name = self.__get_qualified_name(node.name)
+        cls.ln_col = self.__get_line_column_no(node)
         self.cls_may_vars_use = []
         self.cls_list.append(cls)
 

--- a/libsa4py/representations.py
+++ b/libsa4py/representations.py
@@ -74,19 +74,22 @@ class ClassInfo:
     def __init__(self):
         self.name: str = ''
         self.q_name: str = ''
+        # Line, Column no. for the start and end of the class
+        self.ln_col: Tuple[Tuple[int, int], Tuple[int, int]] = None
         self.variables: Dict[str, str] = {}
         self.variables_use_occur: Dict[str, list] = {}
         self.variables_ln: Dict[str, Tuple[Tuple[int, int], Tuple[int, int]]] = {}
         self.funcs: List[FunctionInfo] = []
 
     def to_dict(self) -> dict:
-        return {"name": self.name, "q_name": self.q_name, "variables": self.variables,
+        return {"name": self.name, "q_name": self.q_name, "cls_lc": self.ln_col, "variables": self.variables,
                 "cls_var_occur": self.variables_use_occur, "cls_var_ln": self.variables_ln,
                 "funcs": [f.to_dict() for f in self.funcs]}
 
     def from_dict(self, cls_repr_dict: dict):
         self.name = cls_repr_dict['name']
         self.q_name = cls_repr_dict['q_name']
+        self.ln_col = (tuple(cls_repr_dict['cls_lc'][0]), tuple(cls_repr_dict['cls_lc'][1]))
         self.variables = cls_repr_dict['variables']
         self.variables_use_occur = cls_repr_dict['cls_var_occur']
         self.variables_ln = {v: (tuple(l[0]), tuple(l[1])) for v, l in cls_repr_dict['cls_var_ln'].items()}
@@ -97,6 +100,7 @@ class ClassInfo:
     def __eq__(self, other_class_info_obj: 'ClassInfo'):
         return other_class_info_obj.name == self.name and \
                other_class_info_obj.q_name == self.q_name and \
+               other_class_info_obj.ln_col == self.ln_col and \
                other_class_info_obj.variables == self.variables and \
                other_class_info_obj.variables_use_occur == self.variables_use_occur and \
                other_class_info_obj.variables_ln == self.variables_ln and \

--- a/tests/exp_outputs/extractor_out.json
+++ b/tests/exp_outputs/extractor_out.json
@@ -28,6 +28,16 @@
         {
             "name": "MyClass",
             "q_name": "MyClass",
+            "cls_lc": [
+                [
+                    12,
+                    0
+                ],
+                [
+                    23,
+                    44
+                ]
+            ],
             "variables": {
                 "cls_var": "builtins.int"
             },
@@ -203,6 +213,16 @@
         {
             "name": "Bar",
             "q_name": "Bar",
+            "cls_lc": [
+                [
+                    26,
+                    0
+                ],
+                [
+                    28,
+                    12
+                ]
+            ],
             "variables": {},
             "cls_var_occur": {},
             "cls_var_ln": {},

--- a/tests/exp_outputs/extractor_out_wo_seq2seq.json
+++ b/tests/exp_outputs/extractor_out_wo_seq2seq.json
@@ -28,6 +28,16 @@
         {
             "name": "MyClass",
             "q_name": "MyClass",
+            "cls_lc": [
+                [
+                    12,
+                    0
+                ],
+                [
+                    23,
+                    44
+                ]
+            ],
             "variables": {
                 "cls_var": "builtins.int"
             },
@@ -203,6 +213,16 @@
         {
             "name": "Bar",
             "q_name": "Bar",
+            "cls_lc": [
+                [
+                    26,
+                    0
+                ],
+                [
+                    28,
+                    12
+                ]
+            ],
             "variables": {},
             "cls_var_occur": {},
             "cls_var_ln": {},

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -135,6 +135,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                19,
+                                0
+                            ],
+                            [
+                                29,
+                                12
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -505,6 +515,16 @@
                     {
                         "name": "Delta",
                         "q_name": "Foo.__init__.<locals>.Delta",
+                        "cls_lc": [
+                            [
+                                33,
+                                8
+                            ],
+                            [
+                                34,
+                                16
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -513,6 +533,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                30,
+                                0
+                            ],
+                            [
+                                46,
+                                22
+                            ]
+                        ],
                         "variables": {
                             "foo seq": "collections.abc.Sequence"
                         },
@@ -793,6 +823,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                17,
+                                34
+                            ]
+                        ],
                         "variables": {
                             "me": "builtins.float",
                             "fox": ""
@@ -1063,6 +1103,16 @@
                     {
                         "name": "TestVarArgOccur",
                         "q_name": "TestVarArgOccur",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                108,
+                                63
+                            ]
+                        ],
                         "variables": {
                             "greet": "builtins.str",
                             "num": "",
@@ -2119,6 +2169,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                11,
+                                0
+                            ],
+                            [
+                                15,
+                                28
+                            ]
+                        ],
                         "variables": {
                             "class var": "builtins.str"
                         },
@@ -2366,6 +2426,16 @@
                     {
                         "name": "Test",
                         "q_name": "Test",
+                        "cls_lc": [
+                            [
+                                16,
+                                0
+                            ],
+                            [
+                                37,
+                                49
+                            ]
+                        ],
                         "variables": {
                             "x": "",
                             "u": "",
@@ -2980,6 +3050,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                10,
+                                0
+                            ],
+                            [
+                                23,
+                                20
+                            ]
+                        ],
                         "variables": {
                             "foo num": "",
                             "foo name": "",
@@ -3391,6 +3471,16 @@
                     {
                         "name": "Delta",
                         "q_name": "Delta",
+                        "cls_lc": [
+                            [
+                                21,
+                                0
+                            ],
+                            [
+                                23,
+                                24
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -4312,6 +4402,16 @@
                     {
                         "name": "MyClass",
                         "q_name": "MyClass",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                23,
+                                44
+                            ]
+                        ],
                         "variables": {
                             "cl var": "builtins.int"
                         },
@@ -4471,6 +4571,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                26,
+                                0
+                            ],
+                            [
+                                28,
+                                12
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -135,6 +135,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                19,
+                                0
+                            ],
+                            [
+                                29,
+                                12
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -513,6 +523,16 @@
                     {
                         "name": "Delta",
                         "q_name": "Foo.__init__.<locals>.Delta",
+                        "cls_lc": [
+                            [
+                                33,
+                                8
+                            ],
+                            [
+                                34,
+                                16
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -521,6 +541,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                30,
+                                0
+                            ],
+                            [
+                                46,
+                                22
+                            ]
+                        ],
                         "variables": {
                             "foo_seq": "collections.abc.Sequence"
                         },
@@ -821,6 +851,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                17,
+                                34
+                            ]
+                        ],
                         "variables": {
                             "me": "builtins.float",
                             "fox": ""
@@ -1125,6 +1165,16 @@
                     {
                         "name": "TestVarArgOccur",
                         "q_name": "TestVarArgOccur",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                108,
+                                63
+                            ]
+                        ],
                         "variables": {
                             "greeting": "builtins.str",
                             "num": "",
@@ -2376,6 +2426,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                11,
+                                0
+                            ],
+                            [
+                                15,
+                                28
+                            ]
+                        ],
                         "variables": {
                             "class_var": "builtins.str"
                         },
@@ -2637,6 +2697,16 @@
                     {
                         "name": "Test",
                         "q_name": "Test",
+                        "cls_lc": [
+                            [
+                                16,
+                                0
+                            ],
+                            [
+                                37,
+                                49
+                            ]
+                        ],
                         "variables": {
                             "x": "",
                             "u": "",
@@ -3301,6 +3371,16 @@
                     {
                         "name": "Foo",
                         "q_name": "Foo",
+                        "cls_lc": [
+                            [
+                                10,
+                                0
+                            ],
+                            [
+                                23,
+                                20
+                            ]
+                        ],
                         "variables": {
                             "foo_num": "",
                             "foo_name": "",
@@ -3752,6 +3832,16 @@
                     {
                         "name": "Delta",
                         "q_name": "Delta",
+                        "cls_lc": [
+                            [
+                                21,
+                                0
+                            ],
+                            [
+                                23,
+                                24
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},
@@ -4771,6 +4861,16 @@
                     {
                         "name": "MyClass",
                         "q_name": "MyClass",
+                        "cls_lc": [
+                            [
+                                12,
+                                0
+                            ],
+                            [
+                                23,
+                                44
+                            ]
+                        ],
                         "variables": {
                             "cls_var": "builtins.int"
                         },
@@ -4946,6 +5046,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                26,
+                                0
+                            ],
+                            [
+                                28,
+                                12
+                            ]
+                        ],
                         "variables": {},
                         "cls_var_occur": {},
                         "cls_var_ln": {},

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -23,7 +23,8 @@ class TestModuleRepresentations(unittest.TestCase):
         self.assertListEqual(mod_repr_dict_key_exp, list(processed_f.to_dict().keys()))
 
     def test_mod_repr_cls_dict(self):
-        cls_repr_mod_exp = [{'name': 'MyClass', 'q_name': 'MyClass', 'variables': {'cls_var': 'builtins.int'},
+        cls_repr_mod_exp = [{'name': 'MyClass', 'q_name': 'MyClass', 'cls_lc': ((12, 0), (23, 44)),
+                             'variables': {'cls_var': 'builtins.int'},
                              'cls_var_occur': {'cls_var': [['MyClass', 'cls_var', 'c', 'n']]},
                              'cls_var_ln': {'cls_var': ((16, 4), (16, 11))},
                              'funcs': [{'name': '__init__', 'q_name': 'MyClass.__init__', 'fn_lc': ((18, 4), (19, 18)),
@@ -44,7 +45,8 @@ class TestModuleRepresentations(unittest.TestCase):
                                         'fn_var_ln': {'n': ((22, 8), (22, 9))},
                                         'params_descr': {'self': '', 'c': ''},
                                         'docstring': {'func': None, 'ret': None, 'long_descr': None}}]},
-                            {'name': 'Bar', 'q_name': 'Bar', 'variables': {}, 'cls_var_occur': {}, 'cls_var_ln': {},
+                            {'name': 'Bar', 'q_name': 'Bar', 'cls_lc': ((26, 0), (28, 12)), 'variables': {},
+                             'cls_var_occur': {}, 'cls_var_ln': {},
                              'funcs': [{'name': '__init__', 'q_name': 'Bar.__init__', 'fn_lc': ((27, 4), (28, 12)),
                                         'params': {'self': ''}, 'ret_exprs': [],
                                         'params_occur': {'self': []}, 'ret_type': '', 'variables': {},
@@ -111,7 +113,7 @@ class TestClassRepresentation(unittest.TestCase):
         self.maxDiff = None
 
     def test_cls_repr_dict_keys(self):
-        cls_repr_dict_keys = ['name', 'q_name', 'variables', 'cls_var_occur', 'cls_var_ln', 'funcs']
+        cls_repr_dict_keys = ['name', 'q_name', 'cls_lc', 'variables', 'cls_var_occur', 'cls_var_ln', 'funcs']
         self.assertListEqual(cls_repr_dict_keys, list((processed_f.to_dict()['classes'][0].keys())))
 
     def test_cls_repr_name_dict(self):


### PR DESCRIPTION
This PR extends the `Visitor` class to include line and column no. info for the start and end of classes in the JSON output.