### PR TITLE
A CST visitor for counting type annotations in source files

### DIFF
--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -726,3 +726,26 @@ class Visitor(cst.CSTVisitor):
     def __get_line_column_no(self, node) -> Tuple[Tuple[int, int], Tuple[int, int]]:
         lc = self.get_metadata(cst.metadata.PositionProvider, node)
         return (lc.start.line, lc.start.column), (lc.end.line, lc.end.column)
+
+
+class TypeAnnotationCounter(cst.CSTVisitor):
+    """
+    It counts the number of type annotations in a Python source code file
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.total_no_type_annot = 0
+
+    def visit_FunctionDef(self, node: cst.FunctionDef):
+        if node.returns is not None:
+            self.total_no_type_annot += 1
+
+    def visit_Param(self, node: cst.Param):
+        if node.annotation is not None:
+            self.total_no_type_annot += 1
+        return False
+
+    def visit_AnnAssign(self, node: cst.AnnAssign):
+        self.total_no_type_annot += 1
+        return False

--- a/tests/examples/type_annot_count.py
+++ b/tests/examples/type_annot_count.py
@@ -1,0 +1,18 @@
+"""
+An example for counting type annotations
+"""
+# 1
+m: int = 10
+
+class Bar:
+    bar_var1: float = 2.17 # 2
+    bar_var2: int # 3
+    def __init__(self, i: int): # 4
+        self.i: int = i # 5
+    # 6, 7
+    def bar_fn(self, x: float, y: float) -> float: # 8
+        return x + y
+# 9, 10
+def foo(n: str, i:bool=False):
+    if i:
+        z: str = "Hello" + n # 11

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -1884,6 +1884,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                7,
+                                0
+                            ],
+                            [
+                                14,
+                                20
+                            ]
+                        ],
                         "variables": {
                             "bar var": "builtins.int"
                         },

--- a/tests/exp_outputs/testsexamples.json
+++ b/tests/exp_outputs/testsexamples.json
@@ -1808,6 +1808,256 @@
                 },
                 "type_annot_cove": 1.0
             },
+            "libsa4py/tests/examples/type_annot_count.py": {
+                "untyped_seq": "[docstring] [EOL] [comment] [EOL] m = [number] [EOL] [EOL] class Bar : [EOL] bar_var1 = [number] [comment] [EOL] bar_var2 = ... [comment] [EOL] def __init__ ( self , i ) : [comment] [EOL] self . i = i [comment] [EOL] [comment] [EOL] def bar_fn ( self , x , y ) : [comment] [EOL] return x + y [EOL] [comment] [EOL] def foo ( n , i = False ) : [EOL] if i : [EOL] z = [string] + n [comment]",
+                "typed_seq": "0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [],
+                "variables": {
+                    "m": "builtins.int"
+                },
+                "mod_var_occur": {
+                    "m": []
+                },
+                "mod_var_ln": {
+                    "m": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5,
+                            1
+                        ]
+                    ]
+                },
+                "classes": [
+                    {
+                        "name": "Bar",
+                        "q_name": "Bar",
+                        "variables": {
+                            "bar var": "builtins.int"
+                        },
+                        "cls_var_occur": {
+                            "bar_var1": [],
+                            "bar_var2": []
+                        },
+                        "cls_var_ln": {
+                            "bar_var1": [
+                                [
+                                    8,
+                                    4
+                                ],
+                                [
+                                    8,
+                                    12
+                                ]
+                            ],
+                            "bar_var2": [
+                                [
+                                    9,
+                                    4
+                                ],
+                                [
+                                    9,
+                                    12
+                                ]
+                            ]
+                        },
+                        "funcs": [
+                            {
+                                "name": "init",
+                                "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        10,
+                                        4
+                                    ],
+                                    [
+                                        11,
+                                        32
+                                    ]
+                                ],
+                                "params": {
+                                    "self": "",
+                                    "i": "builtins.int"
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": [
+                                        "self",
+                                        "",
+                                        "builtins",
+                                        "int",
+                                        ""
+                                    ],
+                                    "i": [
+                                        "self",
+                                        "",
+                                        "builtins",
+                                        "int",
+                                        ""
+                                    ]
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "i": "builtins.int"
+                                },
+                                "fn_var_occur": {
+                                    "i": [
+                                        "self",
+                                        "",
+                                        "builtins",
+                                        "int",
+                                        ""
+                                    ]
+                                },
+                                "fn_var_ln": {
+                                    "i": [
+                                        [
+                                            11,
+                                            8
+                                        ],
+                                        [
+                                            11,
+                                            14
+                                        ]
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": "",
+                                    "i": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            },
+                            {
+                                "name": "bar fn",
+                                "q_name": "Bar.bar_fn",
+                                "fn_lc": [
+                                    [
+                                        13,
+                                        4
+                                    ],
+                                    [
+                                        14,
+                                        20
+                                    ]
+                                ],
+                                "params": {
+                                    "self": "",
+                                    "x": "builtins.float",
+                                    "y": "builtins.float"
+                                },
+                                "ret_exprs": [
+                                    "x y"
+                                ],
+                                "params_occur": {
+                                    "self": [],
+                                    "x": [
+                                        "x",
+                                        ""
+                                    ],
+                                    "y": [
+                                        "x",
+                                        ""
+                                    ]
+                                },
+                                "ret_type": "builtins.float",
+                                "variables": {},
+                                "fn_var_occur": {},
+                                "fn_var_ln": {},
+                                "params_descr": {
+                                    "self": "",
+                                    "x": "",
+                                    "y": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "funcs": [
+                    {
+                        "name": "foo",
+                        "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                16,
+                                0
+                            ],
+                            [
+                                18,
+                                37
+                            ]
+                        ],
+                        "params": {
+                            "n": "builtins.str",
+                            "i": "builtins.bool"
+                        },
+                        "ret_exprs": [],
+                        "params_occur": {
+                            "n": [
+                                "z",
+                                "builtins",
+                                "str",
+                                "n"
+                            ],
+                            "i": []
+                        },
+                        "ret_type": "",
+                        "variables": {
+                            "z": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "z": [
+                                "z",
+                                "builtins",
+                                "str",
+                                "n"
+                            ]
+                        },
+                        "fn_var_ln": {
+                            "z": [
+                                [
+                                    18,
+                                    8
+                                ],
+                                [
+                                    18,
+                                    9
+                                ]
+                            ]
+                        },
+                        "params_descr": {
+                            "n": "",
+                            "i": ""
+                        },
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    }
+                ],
+                "set": null,
+                "tc": [
+                    false,
+                    null
+                ],
+                "no_types_annot": {
+                    "U": 2,
+                    "D": 10,
+                    "I": 0
+                },
+                "type_annot_cove": 0.83
+            },
             "libsa4py/tests/examples/docstrings.py": {
                 "untyped_seq": "def basic_docstring ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] [comment] [EOL] def google_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def rest_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def numpy_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def no_docstring ( ) : [EOL] return None [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -4651,6 +4901,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.37
+        "type_annot_cove": 0.4
     }
 }

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -2047,6 +2047,271 @@
                 },
                 "type_annot_cove": 1.0
             },
+            "libsa4py/tests/examples/type_annot_count.py": {
+                "untyped_seq": "[docstring] [EOL] [comment] [EOL] m = [number] [EOL] [EOL] class Bar : [EOL] bar_var1 = [number] [comment] [EOL] bar_var2 = ... [comment] [EOL] def __init__ ( self , i ) : [comment] [EOL] self . i = i [comment] [EOL] [comment] [EOL] def bar_fn ( self , x , y ) : [comment] [EOL] return x + y [EOL] [comment] [EOL] def foo ( n , i = False ) : [EOL] if i : [EOL] z = [string] + n [comment]",
+                "typed_seq": "0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 $builtins.float$ 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 0 0 0 $builtins.int$ 0 0 0 0 0 0 $builtins.int$ 0 $builtins.int$ 0 0 0 0 0 $builtins.float$ 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 0 0 $builtins.float$ 0 $builtins.float$ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+                "imports": [],
+                "variables": {
+                    "m": "builtins.int"
+                },
+                "mod_var_occur": {
+                    "m": []
+                },
+                "mod_var_ln": {
+                    "m": [
+                        [
+                            5,
+                            0
+                        ],
+                        [
+                            5,
+                            1
+                        ]
+                    ]
+                },
+                "classes": [
+                    {
+                        "name": "Bar",
+                        "q_name": "Bar",
+                        "variables": {
+                            "bar_var1": "builtins.float",
+                            "bar_var2": "builtins.int"
+                        },
+                        "cls_var_occur": {
+                            "bar_var1": [],
+                            "bar_var2": []
+                        },
+                        "cls_var_ln": {
+                            "bar_var1": [
+                                [
+                                    8,
+                                    4
+                                ],
+                                [
+                                    8,
+                                    12
+                                ]
+                            ],
+                            "bar_var2": [
+                                [
+                                    9,
+                                    4
+                                ],
+                                [
+                                    9,
+                                    12
+                                ]
+                            ]
+                        },
+                        "funcs": [
+                            {
+                                "name": "__init__",
+                                "q_name": "Bar.__init__",
+                                "fn_lc": [
+                                    [
+                                        10,
+                                        4
+                                    ],
+                                    [
+                                        11,
+                                        32
+                                    ]
+                                ],
+                                "params": {
+                                    "self": "",
+                                    "i": "builtins.int"
+                                },
+                                "ret_exprs": [],
+                                "params_occur": {
+                                    "self": [
+                                        [
+                                            "self",
+                                            "i",
+                                            "builtins",
+                                            "int",
+                                            "i"
+                                        ]
+                                    ],
+                                    "i": [
+                                        [
+                                            "self",
+                                            "i",
+                                            "builtins",
+                                            "int",
+                                            "i"
+                                        ]
+                                    ]
+                                },
+                                "ret_type": "",
+                                "variables": {
+                                    "i": "builtins.int"
+                                },
+                                "fn_var_occur": {
+                                    "i": [
+                                        [
+                                            "self",
+                                            "i",
+                                            "builtins",
+                                            "int",
+                                            "i"
+                                        ]
+                                    ]
+                                },
+                                "fn_var_ln": {
+                                    "i": [
+                                        [
+                                            11,
+                                            8
+                                        ],
+                                        [
+                                            11,
+                                            14
+                                        ]
+                                    ]
+                                },
+                                "params_descr": {
+                                    "self": "",
+                                    "i": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            },
+                            {
+                                "name": "bar_fn",
+                                "q_name": "Bar.bar_fn",
+                                "fn_lc": [
+                                    [
+                                        13,
+                                        4
+                                    ],
+                                    [
+                                        14,
+                                        20
+                                    ]
+                                ],
+                                "params": {
+                                    "self": "",
+                                    "x": "builtins.float",
+                                    "y": "builtins.float"
+                                },
+                                "ret_exprs": [
+                                    "return x + y"
+                                ],
+                                "params_occur": {
+                                    "self": [],
+                                    "x": [
+                                        [
+                                            "x",
+                                            "y"
+                                        ]
+                                    ],
+                                    "y": [
+                                        [
+                                            "x",
+                                            "y"
+                                        ]
+                                    ]
+                                },
+                                "ret_type": "builtins.float",
+                                "variables": {},
+                                "fn_var_occur": {},
+                                "fn_var_ln": {},
+                                "params_descr": {
+                                    "self": "",
+                                    "x": "",
+                                    "y": ""
+                                },
+                                "docstring": {
+                                    "func": null,
+                                    "ret": null,
+                                    "long_descr": null
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "funcs": [
+                    {
+                        "name": "foo",
+                        "q_name": "foo",
+                        "fn_lc": [
+                            [
+                                16,
+                                0
+                            ],
+                            [
+                                18,
+                                37
+                            ]
+                        ],
+                        "params": {
+                            "n": "builtins.str",
+                            "i": "builtins.bool"
+                        },
+                        "ret_exprs": [],
+                        "params_occur": {
+                            "n": [
+                                [
+                                    "z",
+                                    "builtins",
+                                    "str",
+                                    "n"
+                                ]
+                            ],
+                            "i": []
+                        },
+                        "ret_type": "",
+                        "variables": {
+                            "z": "builtins.str"
+                        },
+                        "fn_var_occur": {
+                            "z": [
+                                [
+                                    "z",
+                                    "builtins",
+                                    "str",
+                                    "n"
+                                ]
+                            ]
+                        },
+                        "fn_var_ln": {
+                            "z": [
+                                [
+                                    18,
+                                    8
+                                ],
+                                [
+                                    18,
+                                    9
+                                ]
+                            ]
+                        },
+                        "params_descr": {
+                            "n": "",
+                            "i": ""
+                        },
+                        "docstring": {
+                            "func": null,
+                            "ret": null,
+                            "long_descr": null
+                        }
+                    }
+                ],
+                "set": null,
+                "tc": [
+                    false,
+                    null
+                ],
+                "no_types_annot": {
+                    "U": 2,
+                    "D": 10,
+                    "I": 0
+                },
+                "type_annot_cove": 0.83
+            },
             "libsa4py/tests/examples/docstrings.py": {
                 "untyped_seq": "def basic_docstring ( ) : [EOL] [docstring] [EOL] pass [EOL] [EOL] [EOL] [comment] [EOL] def google_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def rest_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def numpy_docstring ( param1 , param2 ) : [EOL] [docstring] [EOL] if len ( param2 ) == param1 : [EOL] return True [EOL] else : [EOL] return False [EOL] [EOL] [EOL] [comment] [EOL] def no_docstring ( ) : [EOL] return None [EOL]",
                 "typed_seq": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
@@ -5128,6 +5393,6 @@
                 "type_annot_cove": 0.0
             }
         },
-        "type_annot_cove": 0.37
+        "type_annot_cove": 0.4
     }
 }

--- a/tests/exp_outputs/testsexamples_nonlp.json
+++ b/tests/exp_outputs/testsexamples_nonlp.json
@@ -2123,6 +2123,16 @@
                     {
                         "name": "Bar",
                         "q_name": "Bar",
+                        "cls_lc": [
+                            [
+                                7,
+                                0
+                            ],
+                            [
+                                14,
+                                20
+                            ]
+                        ],
                         "variables": {
                             "bar_var1": "builtins.float",
                             "bar_var2": "builtins.int"

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,0 +1,25 @@
+"""
+Testing CST Visitors
+"""
+from libsa4py.utils import read_file
+from libsa4py.cst_visitor import TypeAnnotationCounter
+import unittest
+import libcst as cst
+
+
+class TestTypeAnnotationCounter(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.py_src_f = read_file("./examples/type_annot_count.py")
+
+    def test_no_counted_type_annot(self):
+        f_parsed = cst.parse_module(self.py_src_f)
+        tac = TypeAnnotationCounter()
+        f_parsed.visit(tac)
+        expected_no_type_annot = 11
+
+        self.assertEqual(tac.total_no_type_annot, expected_no_type_annot)


### PR DESCRIPTION
It adds a CST visitor (`TypeAnnotationCounter`) that counts the total no. of type annotations in source files.