### PR TITLE
Counting the depth of parametric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to the [LibSA4Py](https://github.com/saltudelft/libsa4py) tool will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Adds the `CountParametricTypeDepth` visitor to count the depth of parametric types.
 
 ## [0.3.0] - 2022-02-17
 ### Added

--- a/libsa4py/cst_visitor.py
+++ b/libsa4py/cst_visitor.py
@@ -750,3 +750,14 @@ class TypeAnnotationCounter(cst.CSTVisitor):
     def visit_AnnAssign(self, node: cst.AnnAssign):
         self.total_no_type_annot += 1
         return False
+
+
+class CountParametricTypeDepth(cst.CSTVisitor):
+    """
+    Counts the depth of parametric types. E.g., List[List[int]] has a depth of 2.
+    """
+    def __init__(self):
+        self.type_annot_depth = 0
+
+    def visit_Subscript(self, node):
+        self.type_annot_depth += 1

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -2,7 +2,7 @@
 Testing CST Visitors
 """
 from libsa4py.utils import read_file
-from libsa4py.cst_visitor import TypeAnnotationCounter
+from libsa4py.cst_visitor import TypeAnnotationCounter, CountParametricTypeDepth
 import unittest
 import libcst as cst
 
@@ -23,3 +23,26 @@ class TestTypeAnnotationCounter(unittest.TestCase):
         expected_no_type_annot = 11
 
         self.assertEqual(tac.total_no_type_annot, expected_no_type_annot)
+
+
+class TestParametricTypeDepthReducer(unittest.TestCase):
+    """
+    It tests counting the depth of parametric types.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __count_depth_param_type(self, param_type: str) -> int:
+        t = cst.parse_module(param_type)
+        cptd_visitor = CountParametricTypeDepth()
+        t.visit(cptd_visitor)
+        return cptd_visitor.type_annot_depth
+
+    def test_count_param_type_depth(self):
+        param_types_expected_depth = [("List[Tuple[str, int]]", 2),
+                                      ("Dict[str, str]", 1),
+                                      ("List[List[Dict[str, Tuple[int]]]]", 4),
+                                      ("List[Dict[str, Tuple[int]]]", 3)]
+        for t, e in param_types_expected_depth:
+            self.assertEqual(self.__count_depth_param_type(t), e)


### PR DESCRIPTION
- Adds a CST Visitor, `CountParametricTypeDepth`, to count the depth of parametric types
- A unit test

It can be used to sanity-check `ParametricTypeDepthReducer`.