### PR TITLE
Use Codecov to show test coverage in README

### DIFF
--- a/.github/workflows/libsa4py_test.yaml
+++ b/.github/workflows/libsa4py_test.yaml
@@ -25,5 +25,10 @@ jobs:
       run: |
         cd tests
         coverage run -m pytest .
+        coverage xml -i
     - name: Upload test coverage to Codecov
       uses: codecov/codecov-action@v2
+      with:
+        files: /home/runner/work/libsa4py/libsa4py/tests/coverage.xml
+        fail_ci_if_error: true
+        verbose: true


### PR DESCRIPTION
This PR fixes an issue with uploading test coverage results to Codecov.