### PR TITLE
A fix for applying type annotations to local variables with same name in different methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the [LibSA4Py](https://github.com/saltudelft/libsa4py) to
 ## [Unreleased]
 ### Added
 - Adds the `CountParametricTypeDepth` visitor to count the depth of parametric types.
+### Fixed
+- Fixed an issue where type annotations for local variables with the same name in methods were not applied (`TypeAlpplier`).
 
 ## [0.3.0] - 2022-02-17
 ### Added

--- a/libsa4py/cst_transformers.py
+++ b/libsa4py/cst_transformers.py
@@ -1040,13 +1040,13 @@ class TypeApplier(cst.CSTTransformer):
 
     def visit_AssignTarget(self, node: cst.AssignTarget):
         if match.matches(node, match.AssignTarget(target=match.Name(value=match.DoNotCare()))):
-            if self.last_visited_assign_t_name == node.target.value:
+            if self.last_visited_assign_t_name == self.__get_qualified_name(node.target):
                 self.last_visited_assign_t_count += 1
             elif self.last_visited_assign_t_count == 0:
                 self.last_visited_assign_t_count = 1
             else:
                 self.last_visited_assign_t_count = 1
-            self.last_visited_assign_t_name = node.target.value
+            self.last_visited_assign_t_name = self.__get_qualified_name(node.target)
 
     def leave_Module(self, original_node: cst.Module, updated_node: cst.Module):
         return updated_node.with_changes(body=self.__get_required_imports() + list(updated_node.body))


### PR DESCRIPTION
Fixes #35.